### PR TITLE
Attempt to simplify usage by returning data instead of axios response

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,11 @@ You can also set request options to each function individually
         }
 
 For further reading, please see our API [documentation](https://op-developer.fi/docs/)
+
+
+## Developing
+
+### Running tests
+- register at https://op-developer.fi
+- create app that has access to all sandbox products (Mobility, Banking, etc)
+- run tests with X_API_KEY=<your api key> npm run test  

--- a/src/apis/Accounts.ts
+++ b/src/apis/Accounts.ts
@@ -1,6 +1,5 @@
-import axios from 'axios';
-
 import { Options } from '../utils/DataSchemas';
+import request from '../utils/request';
 
 export default class Accounts {
     options: Options;
@@ -8,33 +7,15 @@ export default class Accounts {
         this.options = options;
     }
     async getAll() {
-        const requestOptions = Object.assign({}, this.options, {
-            method: 'GET',
-            url: `/${this.options.version}/accounts`
-        });
-        return axios(requestOptions);
+        return request('GET', `/${this.options.version}/accounts`, this.options);
     }
     async getById(accountId: String) {
-        const requestOptions = Object.assign({}, this.options, {
-            method: 'GET',
-            url: `/${this.options.version}/accounts/${accountId}`
-        });
-        return axios(requestOptions);
+        return request('GET', `/${this.options.version}/accounts/${accountId}`, this.options);
     }
     async getTransactions(accountId: String) {
-        const requestOptions = Object.assign({}, this.options, {
-            method: 'GET',
-            url: `/${this.options.version}/accounts/${accountId}/transactions`
-        });
-        return axios(requestOptions);
+        return request('GET', `/${this.options.version}/accounts/${accountId}/transactions`, this.options);
     }
     async getTransactionsById(accountId: String, transactionId: String) {
-        const requestOptions = Object.assign({}, this.options, {
-            method: 'GET',
-            url: `/${
-                this.options.version
-            }/accounts/${accountId}/transactions/${transactionId}`
-        });
-        return axios(requestOptions);
+        return request('GET', `/${this.options.version}/accounts/${accountId}/transactions/${transactionId}`, this.options);
     }
 }

--- a/src/apis/Funds.ts
+++ b/src/apis/Funds.ts
@@ -1,6 +1,5 @@
-import axios from 'axios';
-
 import { FundOrderRequest, Options } from '../utils/DataSchemas';
+import request from "../utils/request";
 
 export default class Funds {
     options: Options;
@@ -8,26 +7,20 @@ export default class Funds {
         this.options = options;
     }
     async getFunds() {
-        const requestOptions = Object.assign({}, this.options, {
-            method: 'GET',
-            url: `/${this.options.version}/funds`
-        });
-        return axios(requestOptions);
+        return request('GET', `/${this.options.version}/funds`, this.options);
     }
     async postSubscription(data: FundOrderRequest, isinCode: String) {
-        const requestOptions = Object.assign({}, this.options, {
-            method: 'POST',
-            url: `/${this.options.version}/funds/${isinCode}/subscriptions`,
+        const requestOptions: Options = {
+            ...this.options,
             data: data
-        });
-        return axios(requestOptions);
+        };
+        return request('POST', `/${this.options.version}/funds/${isinCode}/subscriptions`, requestOptions);
     }
     async postRedemption(data: FundOrderRequest, isinCode: String) {
-        const requestOptions = Object.assign({}, this.options, {
-            method: 'POST',
-            url: `/${this.options.version}/funds/${isinCode}/redemptions`,
+        const requestOptions: Options = {
+            ...this.options,
             data: data
-        });
-        return axios(requestOptions);
+        };
+        return request('POST', `/${this.options.version}/funds/${isinCode}/redemptions`, requestOptions);
     }
 }

--- a/src/apis/Holdings.ts
+++ b/src/apis/Holdings.ts
@@ -1,6 +1,5 @@
-import axios from 'axios';
-
 import { Options } from '../utils/DataSchemas';
+import request from '../utils/request';
 
 export default class Holdings {
     options: Options;
@@ -8,10 +7,6 @@ export default class Holdings {
         this.options = options;
     }
     async getHoldings() {
-        const requestOptions = Object.assign({}, this.options, {
-            method: 'GET',
-            url: `/${this.options.version}/holdings`
-        });
-        return axios(requestOptions);
+        return request('GET', `/${this.options.version}/holdings`, this.options);
     }
 }

--- a/src/apis/Mobility.ts
+++ b/src/apis/Mobility.ts
@@ -1,6 +1,5 @@
-import axios from 'axios';
-import * as qs from 'querystring';
 import { Options } from '../utils/DataSchemas';
+import request from "../utils/request";
 
 export default class Mobility {
     options: Options;
@@ -13,11 +12,7 @@ export default class Mobility {
         query: string = ''
     ) {
         const queryString = makeQueryString([bbox, location, query]);
-        const requestOptions = Object.assign({}, this.options, {
-            method: 'GET',
-            url: `/mobility/${this.options.version}/branches${queryString}`
-        });
-        return axios(requestOptions);
+        return request('GET', `/mobility/${this.options.version}/branches${queryString}`, this.options);
     }
     async getBranchesAsJson(
         bbox: string = '',
@@ -25,11 +20,7 @@ export default class Mobility {
         query: string = ''
     ) {
         const queryString = makeQueryString([bbox, location, query]);
-        const requestOptions = Object.assign({}, this.options, {
-            method: 'GET',
-            url: `/mobility/${this.options.version}/branches.json${queryString}`
-        });
-        return axios(requestOptions);
+        return request('GET', `/mobility/${this.options.version}/branches.json${queryString}`, this.options);
     }
     async getBranchesAsGeoJson(
         bbox: string = '',
@@ -37,13 +28,7 @@ export default class Mobility {
         query: string = ''
     ) {
         const queryString = makeQueryString([bbox, location, query]);
-        const requestOptions = Object.assign({}, this.options, {
-            method: 'GET',
-            url: `/mobility/${
-                this.options.version
-            }/branches.geojson${queryString}`
-        });
-        return axios(requestOptions);
+        return request('GET', `/mobility/${this.options.version}/branches.geojson${queryString}`, this.options);
     }
 }
 

--- a/src/apis/Payments.ts
+++ b/src/apis/Payments.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import request from "../utils/request";
 
 import { PaymentData, PaymentConfirmData, Options } from '../utils/DataSchemas';
 
@@ -8,19 +8,17 @@ export default class Payments {
         this.options = options;
     }
     async initiate(body: PaymentData) {
-        const requestOptions = Object.assign({}, this.options, {
-            method: 'POST',
-            url: `/${this.options.version}/payments/initiate`,
+        const requestOptions: Options = {
+            ...this.options,
             data: body
-        });
-        return axios(requestOptions);
+        };
+        return request('POST', `/${this.options.version}/payments/initiate`, requestOptions);
     }
     async confirm(body: PaymentConfirmData) {
-        const requestOptions = Object.assign({}, this.options, {
-            method: 'POST',
-            url: `/${this.options.version}/payments/confirm`,
+        const requestOptions: Options = {
+            ...this.options,
             data: body
-        });
-        return axios(requestOptions);
+        };
+        return request('POST', `/${this.options.version}/payments/confirm`, requestOptions);
     }
 }

--- a/src/utils/DataSchemas.ts
+++ b/src/utils/DataSchemas.ts
@@ -5,38 +5,38 @@ export interface Holding {
 }
 
 export interface AccountType {
-    accountId?: String;
-    accountType?: String;
-    iban?: String;
-    bic?: String;
-    accountName?: String;
+    accountId?: string;
+    accountType?: string;
+    iban?: string;
+    bic?: string;
+    accountName?: string;
     balance?: number;
     amountAvailable?: number;
-    currency?: String;
-    status?: String;
-    ownerId?: String;
-    ownerName?: String;
+    currency?: string;
+    status?: string;
+    ownerId?: string;
+    ownerName?: string;
 }
 export interface Transaction {
-    valueDate?: String;
-    bookingDate?: String;
+    valueDate?: string;
+    bookingDate?: string;
     amount?: number;
-    currency?: String;
-    message?: String;
-    payerIban?: String;
-    receiverIban: String;
-    type?: String;
-    purpose?: String;
-    accountId?: String;
-    reference?: String;
-    transactionId?: String;
+    currency?: string;
+    message?: string;
+    payerIban?: string;
+    receiverIban: string;
+    type?: string;
+    purpose?: string;
+    accountId?: string;
+    reference?: string;
+    transactionId?: string;
 }
 
 export interface Fund {
-    isinCode?: String;
-    nameOfFund?: String;
+    isinCode?: string;
+    nameOfFund?: string;
     unitPrice?: number;
-    timestamp?: String;
+    timestamp?: string;
     documents?: FundDocument;
 }
 
@@ -51,42 +51,43 @@ export interface FundOrderRequest {
 
 export interface PaymentData {
     amount: number;
-    subject?: String;
-    currency?: String;
-    payerIban: String;
-    paymentId?: String;
-    valueDate?: String;
-    receiverBic?: String;
-    receiverIban: String;
-    receiverName?: String;
+    subject?: string;
+    currency?: string;
+    payerIban: string;
+    paymentId?: string;
+    valueDate?: string;
+    receiverBic?: string;
+    receiverIban: string;
+    receiverName?: string;
 }
 
 export interface PaymentConfirmData {
     amount?: number;
-    subject?: String;
-    currency?: String;
-    payerIban?: String;
-    paymentId: String;
-    valueDate?: String;
-    receiverBic?: String;
-    receiverIban?: String;
-    receiverName?: String;
+    subject?: string;
+    currency?: string;
+    payerIban?: string;
+    paymentId: string;
+    valueDate?: string;
+    receiverBic?: string;
+    receiverIban?: string;
+    receiverName?: string;
 }
 
 export interface Options {
     headers?: Headers;
-    baseURL?: String;
-    url?: String;
-    version?: String;
+    baseURL?: string;
+    url?: string;
+    version?: string;
     json?: boolean;
     timeout?: number;
+    data?: object;
 }
 
 export interface Headers {
-    'x-request-id'?: String;
-    'x-session-id'?: String;
-    'x-authorization'?: String;
-    'x-api-key': String;
+    'x-request-id'?: string;
+    'x-session-id'?: string;
+    'x-authorization'?: string;
+    'x-api-key': string;
 }
 
 interface SumOfAllHoldings {
@@ -96,8 +97,8 @@ interface SumOfAllHoldings {
     changeAsPercentage?: number;
 }
 interface FundHolding {
-    fundName?: String;
-    isinCode?: String;
+    fundName?: string;
+    isinCode?: string;
     marketValue?: number;
     changeOfValue?: number;
     holdingItem?: HoldingItem;
@@ -110,12 +111,12 @@ interface HoldingItem {
 }
 
 interface FundDocument {
-    FUND_BROCHURE?: String;
-    PRICE_LIST?: String;
-    ONLINE_SALES?: String;
-    YEAR_REPORT?: String;
-    QUART_REPORT?: String;
-    WEEK_REPORT?: String;
-    MIDYEAR_REPORT?: String;
-    RULES?: String;
+    FUND_BROCHURE?: string;
+    PRICE_LIST?: string;
+    ONLINE_SALES?: string;
+    YEAR_REPORT?: string;
+    QUART_REPORT?: string;
+    WEEK_REPORT?: string;
+    MIDYEAR_REPORT?: string;
+    RULES?: string;
 }

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -1,0 +1,16 @@
+import axios, {AxiosRequestConfig} from "axios";
+import {Options} from './DataSchemas';
+
+const request = async (method: string, path: string, options: Options) => {
+    const requestOptions: AxiosRequestConfig = {
+        headers: options.headers,
+        baseURL: options.baseURL,
+        timeout: options.timeout,
+        method: method,
+        url: path,
+        data: options.data
+    };
+    return axios(requestOptions).then(response => response.data, response => Promise.reject(response));
+};
+
+export default request;

--- a/tests/account.test.ts
+++ b/tests/account.test.ts
@@ -14,9 +14,9 @@ const client = new Client({ headers });
 describe('Accounts', () => {
     it('Should return more than 1 account.', done => {
         client.getAllAccounts().then(accounts => {
-            chai.expect(accounts.data).length.to.be.above(1);
+            chai.expect(accounts).length.to.be.above(1);
             chai
-                .expect(accounts.data)
+                .expect(accounts)
                 .to.have.nested.property('[0]')
                 .with.property('accountId');
             done();
@@ -26,9 +26,9 @@ describe('Accounts', () => {
         client
             .getAccountById('4270acb4db4a8b82c954ff93e5c81f2f38fd5a2f')
             .then(account => {
-                chai.expect(account.data).to.exist;
+                chai.expect(account).to.exist;
                 chai
-                    .expect(account.data)
+                    .expect(account)
                     .to.have.nested.property('[0]')
                     .with.property('accountId')
                     .to.equal('4270acb4db4a8b82c954ff93e5c81f2f38fd5a2f');
@@ -39,9 +39,9 @@ describe('Accounts', () => {
         client
             .getAccountTransactions('5189f37b439bd02462e196e206d0318f094fca82')
             .then(transactions => {
-                chai.expect(transactions.data).length.to.be.above(0);
+                chai.expect(transactions).length.to.be.above(0);
                 chai
-                    .expect(transactions.data)
+                    .expect(transactions)
                     .to.have.nested.property('[0]')
                     .with.property('transactionId');
                 done();
@@ -54,7 +54,7 @@ describe('Accounts', () => {
                 '77302960-fb2b-11e7-a10a-b5588c376575'
             )
             .then(transaction => {
-                chai.expect(transaction.data).to.have.property('transaction');
+                chai.expect(transaction).to.have.property('transaction');
                 done();
             });
     });

--- a/tests/funds.test.ts
+++ b/tests/funds.test.ts
@@ -21,17 +21,17 @@ const accountId = '07618ad83d7c5d5f2db8908d33b6a9272c5e8d96';
 describe('Funds', () => {
     it('Should get all funds', done => {
         client.getFunds().then(funds => {
-            chai.expect(funds.data).to.be.an('array');
+            chai.expect(funds).to.be.an('array');
             chai
-                .expect(funds.data)
+                .expect(funds)
                 .to.have.nested.property('[0]')
                 .with.property('isinCode');
             chai
-                .expect(funds.data)
+                .expect(funds)
                 .to.have.nested.property('[0]')
                 .with.property('unitPrice');
             chai
-                .expect(funds.data)
+                .expect(funds)
                 .to.have.nested.property('[0]')
                 .with.property('nameOfFund');
             done();
@@ -42,7 +42,7 @@ describe('Funds', () => {
             .postSubscription(subscription, 'FI0008800248')
             .then(subscriptionInfo => {
                 chai
-                    .expect(subscriptionInfo.data)
+                    .expect(subscriptionInfo)
                     .to.have.property('subscription')
                     .and.to.have.nested.property('orderIdentifier');
                 done();
@@ -53,7 +53,7 @@ describe('Funds', () => {
             .postRedemption(subscription, 'FI0008800248')
             .then(redemptionInfo => {
                 chai
-                    .expect(redemptionInfo.data)
+                    .expect(redemptionInfo)
                     .to.have.property('subscription')
                     .and.to.have.nested.property('redemptionIdentifier');
                 done();

--- a/tests/holding.test.ts
+++ b/tests/holding.test.ts
@@ -14,9 +14,9 @@ const client = new Client({ headers });
 describe('Holdings', () => {
     it('Should return all holdings from user', done => {
         client.getHoldings().then(holdings => {
-            chai.expect(holdings.data).to.have.property('id');
-            chai.expect(holdings.data).to.have.property('fundHoldings');
-            chai.expect(holdings.data).to.exist;
+            chai.expect(holdings).to.have.property('id');
+            chai.expect(holdings).to.have.property('fundHoldings');
+            chai.expect(holdings).to.exist;
             done();
         });
     });

--- a/tests/mobility.test.ts
+++ b/tests/mobility.test.ts
@@ -14,7 +14,7 @@ const client = new Client({ headers });
 describe('Mobility', () => {
     it('Should get all branches', done => {
         client.getBranches().then(branches => {
-            const branchesArray = branches.data['payload'];
+            const branchesArray = branches['payload'];
             chai.expect(branchesArray).to.exist;
             chai.expect(branchesArray[0]).to.have.property('_id');
             chai.expect(branchesArray[0]).to.have.property('name');
@@ -24,21 +24,21 @@ describe('Mobility', () => {
     });
     it('Should get all branches with search term Helsinki', done => {
         client.getBranches('', '', 'Karjala').then(branches => {
-            const branchesArray = branches.data['payload'];
+            const branchesArray = branches['payload'];
             chai.expect(branchesArray[0]['name']).to.include('KARJALA');
             done();
         });
     });
     it('Should get all branches near coordinates 24.750,60.733 (Riihimäki)', done => {
         client.getBranches('', '24.750,60.733').then(branches => {
-            const branchesArray = branches.data['payload'];
+            const branchesArray = branches['payload'];
             chai.expect(branchesArray[0]['town']).to.equal('RIIHIMÄKI');
             done();
         });
     });
     it('Should get all branches as json', done => {
         client.getBranchesAsJson().then(branches => {
-            const branchesArray = branches.data['payload'];
+            const branchesArray = branches['payload'];
             chai.expect(branchesArray).to.exist;
             chai.expect(branchesArray[0]).to.have.property('_id');
             chai.expect(branchesArray[0]).to.have.property('name');
@@ -48,17 +48,17 @@ describe('Mobility', () => {
     });
     it('Should get all branches as geoJson', done => {
         client.getBranchesAsGeoJson().then(branches => {
-            chai.expect(branches.data).to.have.property('features');
-            chai.expect(branches.data['features']).to.be.an('array');
+            chai.expect(branches).to.have.property('features');
+            chai.expect(branches['features']).to.be.an('array');
             chai
-                .expect(branches.data['features'][0])
+                .expect(branches['features'][0])
                 .to.have.property('geometry')
                 .with.property('coordinates');
             chai
-                .expect(branches.data['features'][0])
+                .expect(branches['features'][0])
                 .to.have.property('properties')
                 .with.property('_id');
-            chai.expect(branches.data['features'][0]).to.have.property('type');
+            chai.expect(branches['features'][0]).to.have.property('type');
             done();
         });
     });

--- a/tests/payment.test.ts
+++ b/tests/payment.test.ts
@@ -23,31 +23,43 @@ const paymentData = {
 };
 
 describe('Payments', () => {
+    it('should fail with proper error message when x-api-key is missing', async () => {
+        expect.assertions(1);
+        const myHeaders = {...headers};
+        delete myHeaders['x-api-key'];
+        const myClient = new Client({ myHeaders });
+        try {
+            await myClient.postPaymentInitiate(paymentData)
+        } catch(error) {
+            expect(String(error)).toEqual("Error: Request failed with status code 400");
+        }
+    });
+
     it('Should initiate payment and confirm payment', done => {
         client
             .postPaymentInitiate(paymentData)
             .then(paymentInfo => {
-                chai.expect(paymentInfo.data).to.have.property('paymentId');
-                chai.expect(paymentInfo.data).to.have.property('amount');
-                chai.expect(paymentInfo.data).to.have.property('payerIban');
-                chai.expect(paymentInfo.data).to.have.property('receiverIban');
-                return paymentInfo.data.paymentId;
+                chai.expect(paymentInfo).to.have.property('paymentId');
+                chai.expect(paymentInfo).to.have.property('amount');
+                chai.expect(paymentInfo).to.have.property('payerIban');
+                chai.expect(paymentInfo).to.have.property('receiverIban');
+                return paymentInfo.paymentId;
             })
             .then(paymentId => {
                 client
                     .postPaymentConfirm({ paymentId: paymentId })
                     .then(confirmInfo => {
                         chai
-                            .expect(confirmInfo.data)
+                            .expect(confirmInfo)
                             .to.have.property('paymentId');
                         chai
-                            .expect(confirmInfo.data)
+                            .expect(confirmInfo)
                             .to.have.property('amount');
                         chai
-                            .expect(confirmInfo.data)
+                            .expect(confirmInfo)
                             .to.have.property('payerIban');
                         chai
-                            .expect(confirmInfo.data)
+                            .expect(confirmInfo)
                             .to.have.property('receiverIban');
                         done();
                     });


### PR DESCRIPTION
I found it confusing that it returned Axios response instead of the data I asked for.

Also, if we ever change axios to eg. fetch, returned object would look completely different, so this is probably better.

Also I tried to simplify axios request construction a bit by introducing request helper that takes care of Axios.

Do note that this is backwards incompatible, so need to figure out how version it, if we choose to merge this.
