### PR TITLE
Update dependencies to fix security vulnerabilities in braces, handlebars, js-yaml, axios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,82 +6,496 @@
     "dependencies": {
         "@babel/code-frame": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-            "integrity":
-                "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+            "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
             "dev": true,
             "requires": {
                 "@babel/highlight": "^7.0.0"
             }
         },
+        "@babel/core": {
+            "version": "7.4.5",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.5.tgz",
+            "integrity": "sha512-OvjIh6aqXtlsA8ujtGKfC7LYWksYSX8yQcM8Ay3LuvVeQ63lcOKgoZWVqcpFwkd29aYU9rVx7jxhfhiEDV9MZA==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/generator": "^7.4.4",
+                "@babel/helpers": "^7.4.4",
+                "@babel/parser": "^7.4.5",
+                "@babel/template": "^7.4.4",
+                "@babel/traverse": "^7.4.5",
+                "@babel/types": "^7.4.4",
+                "convert-source-map": "^1.1.0",
+                "debug": "^4.1.0",
+                "json5": "^2.1.0",
+                "lodash": "^4.17.11",
+                "resolve": "^1.3.2",
+                "semver": "^5.4.1",
+                "source-map": "^0.5.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/generator": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+            "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.4.4",
+                "jsesc": "^2.5.1",
+                "lodash": "^4.17.11",
+                "source-map": "^0.5.0",
+                "trim-right": "^1.0.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-function-name": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+            "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-get-function-arity": "^7.0.0",
+                "@babel/template": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-get-function-arity": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+            "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-plugin-utils": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+            "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+            "dev": true
+        },
+        "@babel/helper-split-export-declaration": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+            "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.4.4"
+            }
+        },
+        "@babel/helpers": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.4.tgz",
+            "integrity": "sha512-igczbR/0SeuPR8RFfC7tGrbdTbFL3QTvH6D+Z6zNxnTe//GyqmtHmDkzrqDmyZ3eSwPqB/LhyKoU5DXsp+Vp2A==",
+            "dev": true,
+            "requires": {
+                "@babel/template": "^7.4.4",
+                "@babel/traverse": "^7.4.4",
+                "@babel/types": "^7.4.4"
+            }
+        },
         "@babel/highlight": {
             "version": "7.0.0",
-            "resolved":
-                "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-            "integrity":
-                "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+            "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
             "dev": true,
             "requires": {
                 "chalk": "^2.0.0",
                 "esutils": "^2.0.2",
                 "js-tokens": "^4.0.0"
+            }
+        },
+        "@babel/parser": {
+            "version": "7.4.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+            "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+            "dev": true
+        },
+        "@babel/plugin-syntax-object-rest-spread": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+            "integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/template": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+            "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/parser": "^7.4.4",
+                "@babel/types": "^7.4.4"
+            }
+        },
+        "@babel/traverse": {
+            "version": "7.4.5",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
+            "integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/generator": "^7.4.4",
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.4.4",
+                "@babel/parser": "^7.4.5",
+                "@babel/types": "^7.4.4",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0",
+                "lodash": "^4.17.11"
             },
             "dependencies": {
-                "js-tokens": {
-                    "version": "4.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-                    "integrity":
-                        "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
                     "dev": true
                 }
             }
         },
+        "@babel/types": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+            "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+            "dev": true,
+            "requires": {
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.11",
+                "to-fast-properties": "^2.0.0"
+            }
+        },
+        "@cnakazawa/watch": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
+            "integrity": "sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==",
+            "dev": true,
+            "requires": {
+                "exec-sh": "^0.3.2",
+                "minimist": "^1.2.0"
+            }
+        },
+        "@jest/console": {
+            "version": "24.7.1",
+            "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.7.1.tgz",
+            "integrity": "sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==",
+            "dev": true,
+            "requires": {
+                "@jest/source-map": "^24.3.0",
+                "chalk": "^2.0.1",
+                "slash": "^2.0.0"
+            }
+        },
+        "@jest/core": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/@jest/core/-/core-24.8.0.tgz",
+            "integrity": "sha512-R9rhAJwCBQzaRnrRgAdVfnglUuATXdwTRsYqs6NMdVcAl5euG8LtWDe+fVkN27YfKVBW61IojVsXKaOmSnqd/A==",
+            "dev": true,
+            "requires": {
+                "@jest/console": "^24.7.1",
+                "@jest/reporters": "^24.8.0",
+                "@jest/test-result": "^24.8.0",
+                "@jest/transform": "^24.8.0",
+                "@jest/types": "^24.8.0",
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.1",
+                "exit": "^0.1.2",
+                "graceful-fs": "^4.1.15",
+                "jest-changed-files": "^24.8.0",
+                "jest-config": "^24.8.0",
+                "jest-haste-map": "^24.8.0",
+                "jest-message-util": "^24.8.0",
+                "jest-regex-util": "^24.3.0",
+                "jest-resolve-dependencies": "^24.8.0",
+                "jest-runner": "^24.8.0",
+                "jest-runtime": "^24.8.0",
+                "jest-snapshot": "^24.8.0",
+                "jest-util": "^24.8.0",
+                "jest-validate": "^24.8.0",
+                "jest-watcher": "^24.8.0",
+                "micromatch": "^3.1.10",
+                "p-each-series": "^1.0.0",
+                "pirates": "^4.0.1",
+                "realpath-native": "^1.1.0",
+                "rimraf": "^2.5.4",
+                "strip-ansi": "^5.0.0"
+            }
+        },
+        "@jest/environment": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.8.0.tgz",
+            "integrity": "sha512-vlGt2HLg7qM+vtBrSkjDxk9K0YtRBi7HfRFaDxoRtyi+DyVChzhF20duvpdAnKVBV6W5tym8jm0U9EfXbDk1tw==",
+            "dev": true,
+            "requires": {
+                "@jest/fake-timers": "^24.8.0",
+                "@jest/transform": "^24.8.0",
+                "@jest/types": "^24.8.0",
+                "jest-mock": "^24.8.0"
+            }
+        },
+        "@jest/fake-timers": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.8.0.tgz",
+            "integrity": "sha512-2M4d5MufVXwi6VzZhJ9f5S/wU4ud2ck0kxPof1Iz3zWx6Y+V2eJrES9jEktB6O3o/oEyk+il/uNu9PvASjWXQw==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^24.8.0",
+                "jest-message-util": "^24.8.0",
+                "jest-mock": "^24.8.0"
+            }
+        },
+        "@jest/reporters": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.8.0.tgz",
+            "integrity": "sha512-eZ9TyUYpyIIXfYCrw0UHUWUvE35vx5I92HGMgS93Pv7du+GHIzl+/vh8Qj9MCWFK/4TqyttVBPakWMOfZRIfxw==",
+            "dev": true,
+            "requires": {
+                "@jest/environment": "^24.8.0",
+                "@jest/test-result": "^24.8.0",
+                "@jest/transform": "^24.8.0",
+                "@jest/types": "^24.8.0",
+                "chalk": "^2.0.1",
+                "exit": "^0.1.2",
+                "glob": "^7.1.2",
+                "istanbul-lib-coverage": "^2.0.2",
+                "istanbul-lib-instrument": "^3.0.1",
+                "istanbul-lib-report": "^2.0.4",
+                "istanbul-lib-source-maps": "^3.0.1",
+                "istanbul-reports": "^2.1.1",
+                "jest-haste-map": "^24.8.0",
+                "jest-resolve": "^24.8.0",
+                "jest-runtime": "^24.8.0",
+                "jest-util": "^24.8.0",
+                "jest-worker": "^24.6.0",
+                "node-notifier": "^5.2.1",
+                "slash": "^2.0.0",
+                "source-map": "^0.6.0",
+                "string-length": "^2.0.0"
+            }
+        },
+        "@jest/source-map": {
+            "version": "24.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.3.0.tgz",
+            "integrity": "sha512-zALZt1t2ou8le/crCeeiRYzvdnTzaIlpOWaet45lNSqNJUnXbppUUFR4ZUAlzgDmKee4Q5P/tKXypI1RiHwgag==",
+            "dev": true,
+            "requires": {
+                "callsites": "^3.0.0",
+                "graceful-fs": "^4.1.15",
+                "source-map": "^0.6.0"
+            }
+        },
+        "@jest/test-result": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.8.0.tgz",
+            "integrity": "sha512-+YdLlxwizlfqkFDh7Mc7ONPQAhA4YylU1s529vVM1rsf67vGZH/2GGm5uO8QzPeVyaVMobCQ7FTxl38QrKRlng==",
+            "dev": true,
+            "requires": {
+                "@jest/console": "^24.7.1",
+                "@jest/types": "^24.8.0",
+                "@types/istanbul-lib-coverage": "^2.0.0"
+            }
+        },
+        "@jest/test-sequencer": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.8.0.tgz",
+            "integrity": "sha512-OzL/2yHyPdCHXEzhoBuq37CE99nkme15eHkAzXRVqthreWZamEMA0WoetwstsQBCXABhczpK03JNbc4L01vvLg==",
+            "dev": true,
+            "requires": {
+                "@jest/test-result": "^24.8.0",
+                "jest-haste-map": "^24.8.0",
+                "jest-runner": "^24.8.0",
+                "jest-runtime": "^24.8.0"
+            }
+        },
+        "@jest/transform": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.8.0.tgz",
+            "integrity": "sha512-xBMfFUP7TortCs0O+Xtez2W7Zu1PLH9bvJgtraN1CDST6LBM/eTOZ9SfwS/lvV8yOfcDpFmwf9bq5cYbXvqsvA==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "^7.1.0",
+                "@jest/types": "^24.8.0",
+                "babel-plugin-istanbul": "^5.1.0",
+                "chalk": "^2.0.1",
+                "convert-source-map": "^1.4.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "graceful-fs": "^4.1.15",
+                "jest-haste-map": "^24.8.0",
+                "jest-regex-util": "^24.3.0",
+                "jest-util": "^24.8.0",
+                "micromatch": "^3.1.10",
+                "realpath-native": "^1.1.0",
+                "slash": "^2.0.0",
+                "source-map": "^0.6.1",
+                "write-file-atomic": "2.4.1"
+            }
+        },
+        "@jest/types": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.8.0.tgz",
+            "integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
+            "dev": true,
+            "requires": {
+                "@types/istanbul-lib-coverage": "^2.0.0",
+                "@types/istanbul-reports": "^1.1.1",
+                "@types/yargs": "^12.0.9"
+            }
+        },
         "@types/axios": {
             "version": "0.14.0",
-            "resolved":
-                "https://registry.npmjs.org/@types/axios/-/axios-0.14.0.tgz",
+            "resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.14.0.tgz",
             "integrity": "sha1-7CMA++fX3d1+udOr+HmZlkyvzkY=",
             "requires": {
                 "axios": "*"
             }
         },
+        "@types/babel__core": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.2.tgz",
+            "integrity": "sha512-cfCCrFmiGY/yq0NuKNxIQvZFy9kY/1immpSpTngOnyIbD4+eJOG5mxphhHDv3CHL9GltO4GcKr54kGBg3RNdbg==",
+            "dev": true,
+            "requires": {
+                "@babel/parser": "^7.1.0",
+                "@babel/types": "^7.0.0",
+                "@types/babel__generator": "*",
+                "@types/babel__template": "*",
+                "@types/babel__traverse": "*"
+            }
+        },
+        "@types/babel__generator": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.0.2.tgz",
+            "integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@types/babel__template": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
+            "integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+            "dev": true,
+            "requires": {
+                "@babel/parser": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@types/babel__traverse": {
+            "version": "7.0.7",
+            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.7.tgz",
+            "integrity": "sha512-CeBpmX1J8kWLcDEnI3Cl2Eo6RfbGvzUctA+CjZUhOKDFbLfcr7fc4usEqLNWetrlJd7RhAkyYe2czXop4fICpw==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.3.0"
+            }
+        },
+        "@types/istanbul-lib-coverage": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+            "integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==",
+            "dev": true
+        },
+        "@types/istanbul-lib-report": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
+            "integrity": "sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==",
+            "dev": true,
+            "requires": {
+                "@types/istanbul-lib-coverage": "*"
+            }
+        },
+        "@types/istanbul-reports": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
+            "integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
+            "dev": true,
+            "requires": {
+                "@types/istanbul-lib-coverage": "*",
+                "@types/istanbul-lib-report": "*"
+            }
+        },
         "@types/jest": {
-            "version": "22.1.3",
-            "resolved":
-                "https://registry.npmjs.org/@types/jest/-/jest-22.1.3.tgz",
-            "integrity":
-                "sha512-qpbOiPE3iqeqnicgOVg6MBgtFMxe0Qd5PHtHp4Y7YGBWnNIgv7Mr2lx7ILEN6d7K+Fub9FW1S3Q2NKvbc+b+AA==",
+            "version": "22.2.3",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-22.2.3.tgz",
+            "integrity": "sha512-e74sM9W/4qqWB6D4TWV9FQk0WoHtX1X4FJpbjxucMSVJHtFjbQOH3H6yp+xno4br0AKG0wz/kPtaN599GUOvAg==",
             "dev": true
         },
         "@types/node": {
-            "version": "10.11.5",
-            "resolved":
-                "https://registry.npmjs.org/@types/node/-/node-10.11.5.tgz",
-            "integrity":
-                "sha512-3j1EFLfrjYRHRFjBb+RIXXwr1YGzcfpQVMP39thZa6tMY+JjVgQddPF+hsdV800JqbuLwpwAWclDpbGSAw44vQ=="
+            "version": "10.14.10",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.10.tgz",
+            "integrity": "sha512-V8wj+w2YMNvGuhgl/MA5fmTxgjmVHVoasfIaxMMZJV6Y8Kk+Ydpi1z2whoShDCJ2BuNVoqH/h1hrygnBxkrw/Q=="
+        },
+        "@types/stack-utils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
+            "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+            "dev": true
+        },
+        "@types/yargs": {
+            "version": "12.0.12",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.12.tgz",
+            "integrity": "sha512-SOhuU4wNBxhhTHxYaiG5NY4HBhDIDnJF60GU+2LqHAdKKer86//e4yg69aENCtQ04n0ovz+tq2YPME5t5yp4pw==",
+            "dev": true
         },
         "abab": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
-            "integrity":
-                "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
+            "integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
             "dev": true
         },
         "acorn": {
             "version": "5.7.3",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-            "integrity":
-                "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+            "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
             "dev": true
         },
         "acorn-globals": {
-            "version": "4.3.0",
-            "resolved":
-                "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.0.tgz",
-            "integrity":
-                "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.2.tgz",
+            "integrity": "sha512-BbzvZhVtZP+Bs1J1HcwrQe8ycfO0wStkSGxuul3He3GkHOIZ6eTqOkPuw9IP1X3+IkOo4wiJmwkobzXYz4wewQ==",
             "dev": true,
             "requires": {
                 "acorn": "^6.0.1",
@@ -89,56 +503,47 @@
             },
             "dependencies": {
                 "acorn": {
-                    "version": "6.0.2",
-                    "resolved":
-                        "https://registry.npmjs.org/acorn/-/acorn-6.0.2.tgz",
-                    "integrity":
-                        "sha512-GXmKIvbrN3TV7aVqAzVFaMW8F8wzVX7voEBRO3bDA64+EX37YSayggRJP5Xig6HYHBkWKpFg9W5gg6orklubhg==",
+                    "version": "6.1.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+                    "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
                     "dev": true
                 }
             }
         },
         "acorn-walk": {
-            "version": "6.1.0",
-            "resolved":
-                "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.0.tgz",
-            "integrity":
-                "sha512-ugTb7Lq7u4GfWSqqpwE0bGyoBZNMTok/zDBXxfEG0QM50jNlGhIWjRC1pPN7bvV1anhF+bs+/gNcRw+o55Evbg==",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
+            "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
             "dev": true
         },
         "ajv": {
-            "version": "5.5.2",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-            "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+            "version": "6.10.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+            "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
             "dev": true,
             "requires": {
-                "co": "^4.6.0",
-                "fast-deep-equal": "^1.0.0",
+                "fast-deep-equal": "^2.0.1",
                 "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.3.0"
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
             }
         },
         "ansi-escapes": {
-            "version": "3.1.0",
-            "resolved":
-                "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-            "integrity":
-                "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+            "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
             "dev": true
         },
         "ansi-regex": {
-            "version": "2.1.1",
-            "resolved":
-                "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+            "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
             "dev": true
         },
         "ansi-styles": {
             "version": "3.2.0",
-            "resolved":
-                "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-            "integrity":
-                "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+            "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
             "dev": true,
             "requires": {
                 "color-convert": "^1.9.0"
@@ -146,387 +551,63 @@
         },
         "anymatch": {
             "version": "2.0.0",
-            "resolved":
-                "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-            "integrity":
-                "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+            "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
             "dev": true,
             "requires": {
                 "micromatch": "^3.1.4",
                 "normalize-path": "^2.1.1"
-            },
-            "dependencies": {
-                "arr-diff": {
-                    "version": "4.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-                    "dev": true
-                },
-                "array-unique": {
-                    "version": "0.3.2",
-                    "resolved":
-                        "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-                    "dev": true
-                },
-                "braces": {
-                    "version": "2.3.2",
-                    "resolved":
-                        "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-                    "integrity":
-                        "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-                    "dev": true,
-                    "requires": {
-                        "arr-flatten": "^1.1.0",
-                        "array-unique": "^0.3.2",
-                        "extend-shallow": "^2.0.1",
-                        "fill-range": "^4.0.0",
-                        "isobject": "^3.0.1",
-                        "repeat-element": "^1.1.2",
-                        "snapdragon": "^0.8.1",
-                        "snapdragon-node": "^2.0.1",
-                        "split-string": "^3.0.2",
-                        "to-regex": "^3.0.1"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved":
-                                "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "dev": true,
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "expand-brackets": {
-                    "version": "2.1.4",
-                    "resolved":
-                        "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-                    "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-                    "dev": true,
-                    "requires": {
-                        "debug": "^2.3.3",
-                        "define-property": "^0.2.5",
-                        "extend-shallow": "^2.0.1",
-                        "posix-character-classes": "^0.1.0",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.1"
-                    },
-                    "dependencies": {
-                        "define-property": {
-                            "version": "0.2.5",
-                            "resolved":
-                                "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-                            "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                            "dev": true,
-                            "requires": {
-                                "is-descriptor": "^0.1.0"
-                            }
-                        },
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved":
-                                "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "dev": true,
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        },
-                        "is-accessor-descriptor": {
-                            "version": "0.1.6",
-                            "resolved":
-                                "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-                            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-                            "dev": true,
-                            "requires": {
-                                "kind-of": "^3.0.2"
-                            },
-                            "dependencies": {
-                                "kind-of": {
-                                    "version": "3.2.2",
-                                    "resolved":
-                                        "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                                    "integrity":
-                                        "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                                    "dev": true,
-                                    "requires": {
-                                        "is-buffer": "^1.1.5"
-                                    }
-                                }
-                            }
-                        },
-                        "is-data-descriptor": {
-                            "version": "0.1.4",
-                            "resolved":
-                                "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-                            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-                            "dev": true,
-                            "requires": {
-                                "kind-of": "^3.0.2"
-                            },
-                            "dependencies": {
-                                "kind-of": {
-                                    "version": "3.2.2",
-                                    "resolved":
-                                        "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                                    "integrity":
-                                        "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                                    "dev": true,
-                                    "requires": {
-                                        "is-buffer": "^1.1.5"
-                                    }
-                                }
-                            }
-                        },
-                        "is-descriptor": {
-                            "version": "0.1.6",
-                            "resolved":
-                                "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-                            "integrity":
-                                "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-                            "dev": true,
-                            "requires": {
-                                "is-accessor-descriptor": "^0.1.6",
-                                "is-data-descriptor": "^0.1.4",
-                                "kind-of": "^5.0.0"
-                            }
-                        },
-                        "kind-of": {
-                            "version": "5.1.0",
-                            "resolved":
-                                "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                            "integrity":
-                                "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-                            "dev": true
-                        }
-                    }
-                },
-                "extglob": {
-                    "version": "2.0.4",
-                    "resolved":
-                        "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-                    "integrity":
-                        "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-                    "dev": true,
-                    "requires": {
-                        "array-unique": "^0.3.2",
-                        "define-property": "^1.0.0",
-                        "expand-brackets": "^2.1.4",
-                        "extend-shallow": "^2.0.1",
-                        "fragment-cache": "^0.2.1",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.1"
-                    },
-                    "dependencies": {
-                        "define-property": {
-                            "version": "1.0.0",
-                            "resolved":
-                                "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-                            "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-                            "dev": true,
-                            "requires": {
-                                "is-descriptor": "^1.0.0"
-                            }
-                        },
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved":
-                                "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "dev": true,
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "fill-range": {
-                    "version": "4.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-                    "dev": true,
-                    "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1",
-                        "to-regex-range": "^2.1.0"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved":
-                                "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "dev": true,
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "is-accessor-descriptor": {
-                    "version": "1.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-                    "integrity":
-                        "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^6.0.0"
-                    }
-                },
-                "is-data-descriptor": {
-                    "version": "1.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-                    "integrity":
-                        "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^6.0.0"
-                    }
-                },
-                "is-descriptor": {
-                    "version": "1.0.2",
-                    "resolved":
-                        "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-                    "integrity":
-                        "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-                    "dev": true,
-                    "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
-                    }
-                },
-                "is-number": {
-                    "version": "3.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved":
-                                "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "dev": true,
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
-                    }
-                },
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved":
-                        "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
-                },
-                "kind-of": {
-                    "version": "6.0.2",
-                    "resolved":
-                        "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity":
-                        "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-                    "dev": true
-                },
-                "micromatch": {
-                    "version": "3.1.10",
-                    "resolved":
-                        "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-                    "integrity":
-                        "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-                    "dev": true,
-                    "requires": {
-                        "arr-diff": "^4.0.0",
-                        "array-unique": "^0.3.2",
-                        "braces": "^2.3.1",
-                        "define-property": "^2.0.2",
-                        "extend-shallow": "^3.0.2",
-                        "extglob": "^2.0.4",
-                        "fragment-cache": "^0.2.1",
-                        "kind-of": "^6.0.2",
-                        "nanomatch": "^1.2.9",
-                        "object.pick": "^1.3.0",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.2"
-                    }
-                }
-            }
-        },
-        "append-transform": {
-            "version": "0.4.0",
-            "resolved":
-                "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
-            "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
-            "dev": true,
-            "requires": {
-                "default-require-extensions": "^1.0.0"
-            }
-        },
-        "argparse": {
-            "version": "1.0.10",
-            "resolved":
-                "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity":
-                "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "dev": true,
-            "requires": {
-                "sprintf-js": "~1.0.2"
             }
         },
         "arr-diff": {
-            "version": "2.0.0",
-            "resolved":
-                "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-            "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-            "dev": true,
-            "requires": {
-                "arr-flatten": "^1.0.1"
-            }
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+            "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+            "dev": true
         },
         "arr-flatten": {
             "version": "1.1.0",
-            "resolved":
-                "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-            "integrity":
-                "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+            "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
             "dev": true
         },
         "arr-union": {
             "version": "3.1.0",
-            "resolved":
-                "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
             "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+            "dev": true
+        },
+        "array-differ": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-2.1.0.tgz",
+            "integrity": "sha512-KbUpJgx909ZscOc/7CLATBFam7P1Z1QRQInvgT0UztM9Q72aGKCunKASAl7WNW0tnPmPyEMeMhdsfWhfmW037w==",
             "dev": true
         },
         "array-equal": {
             "version": "1.0.0",
-            "resolved":
-                "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
             "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
             "dev": true
         },
+        "array-union": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+            "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+            "dev": true,
+            "requires": {
+                "array-uniq": "^1.0.1"
+            }
+        },
+        "array-uniq": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+            "dev": true
+        },
         "array-unique": {
-            "version": "0.2.1",
-            "resolved":
-                "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-            "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+            "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
             "dev": true
         },
         "arrify": {
@@ -538,8 +619,7 @@
         "asn1": {
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-            "integrity":
-                "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+            "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
             "dev": true,
             "requires": {
                 "safer-buffer": "~2.1.0"
@@ -547,344 +627,205 @@
         },
         "assert-plus": {
             "version": "1.0.0",
-            "resolved":
-                "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
             "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
             "dev": true
         },
         "assign-symbols": {
             "version": "1.0.0",
-            "resolved":
-                "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
             "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
             "dev": true
         },
         "astral-regex": {
             "version": "1.0.0",
-            "resolved":
-                "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-            "integrity":
-                "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+            "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
             "dev": true
-        },
-        "async": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-            "integrity":
-                "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-            "dev": true,
-            "requires": {
-                "lodash": "^4.17.10"
-            }
         },
         "async-limiter": {
             "version": "1.0.0",
-            "resolved":
-                "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-            "integrity":
-                "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+            "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+            "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
             "dev": true
         },
         "asynckit": {
             "version": "0.4.0",
-            "resolved":
-                "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
             "dev": true
         },
         "atob": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-            "integrity":
-                "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
             "dev": true
         },
         "aws-sign2": {
             "version": "0.7.0",
-            "resolved":
-                "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
             "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
             "dev": true
         },
         "aws4": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-            "integrity":
-                "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+            "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
             "dev": true
         },
         "axios": {
-            "version": "0.17.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
-            "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+            "version": "0.19.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+            "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
             "requires": {
-                "follow-redirects": "^1.2.5",
-                "is-buffer": "^1.1.5"
+                "follow-redirects": "1.5.10",
+                "is-buffer": "^2.0.2"
+            },
+            "dependencies": {
+                "is-buffer": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+                    "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+                }
             }
         },
-        "babel-code-frame": {
-            "version": "6.26.0",
-            "resolved":
-                "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-            "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+        "babel-jest": {
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.8.0.tgz",
+            "integrity": "sha512-+5/kaZt4I9efoXzPlZASyK/lN9qdRKmmUav9smVc0ruPQD7IsfucQ87gpOE8mn2jbDuS6M/YOW6n3v9ZoIfgnw==",
             "dev": true,
             "requires": {
-                "chalk": "^1.1.3",
-                "esutils": "^2.0.2",
-                "js-tokens": "^3.0.2"
+                "@jest/transform": "^24.8.0",
+                "@jest/types": "^24.8.0",
+                "@types/babel__core": "^7.1.0",
+                "babel-plugin-istanbul": "^5.1.0",
+                "babel-preset-jest": "^24.6.0",
+                "chalk": "^2.4.2",
+                "slash": "^2.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved":
-                        "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
                 },
                 "chalk": {
-                    "version": "1.1.3",
-                    "resolved":
-                        "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved":
-                        "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^2.0.0"
-                    }
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
                 },
                 "supports-color": {
-                    "version": "2.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "babel-plugin-istanbul": {
+            "version": "5.1.4",
+            "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.4.tgz",
+            "integrity": "sha512-dySz4VJMH+dpndj0wjJ8JPs/7i1TdSPb1nRrn56/92pKOF9VKC1FMFJmMXjzlGGusnCAqujP6PBCiKq0sVA+YQ==",
+            "dev": true,
+            "requires": {
+                "find-up": "^3.0.0",
+                "istanbul-lib-instrument": "^3.3.0",
+                "test-exclude": "^5.2.3"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+                    "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
                     "dev": true
                 }
             }
         },
-        "babel-core": {
-            "version": "6.26.3",
-            "resolved":
-                "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-            "integrity":
-                "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-            "dev": true,
-            "requires": {
-                "babel-code-frame": "^6.26.0",
-                "babel-generator": "^6.26.0",
-                "babel-helpers": "^6.24.1",
-                "babel-messages": "^6.23.0",
-                "babel-register": "^6.26.0",
-                "babel-runtime": "^6.26.0",
-                "babel-template": "^6.26.0",
-                "babel-traverse": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "babylon": "^6.18.0",
-                "convert-source-map": "^1.5.1",
-                "debug": "^2.6.9",
-                "json5": "^0.5.1",
-                "lodash": "^4.17.4",
-                "minimatch": "^3.0.4",
-                "path-is-absolute": "^1.0.1",
-                "private": "^0.1.8",
-                "slash": "^1.0.0",
-                "source-map": "^0.5.7"
-            }
-        },
-        "babel-generator": {
-            "version": "6.26.1",
-            "resolved":
-                "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-            "integrity":
-                "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
-            "dev": true,
-            "requires": {
-                "babel-messages": "^6.23.0",
-                "babel-runtime": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "detect-indent": "^4.0.0",
-                "jsesc": "^1.3.0",
-                "lodash": "^4.17.4",
-                "source-map": "^0.5.7",
-                "trim-right": "^1.0.1"
-            }
-        },
-        "babel-helpers": {
-            "version": "6.24.1",
-            "resolved":
-                "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-            "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1"
-            }
-        },
-        "babel-jest": {
-            "version": "23.6.0",
-            "resolved":
-                "https://registry.npmjs.org/babel-jest/-/babel-jest-23.6.0.tgz",
-            "integrity":
-                "sha512-lqKGG6LYXYu+DQh/slrQ8nxXQkEkhugdXsU6St7GmhVS7Ilc/22ArwqXNJrf0QaOBjZB0360qZMwXqDYQHXaew==",
-            "dev": true,
-            "requires": {
-                "babel-plugin-istanbul": "^4.1.6",
-                "babel-preset-jest": "^23.2.0"
-            }
-        },
-        "babel-messages": {
-            "version": "6.23.0",
-            "resolved":
-                "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-            "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-istanbul": {
-            "version": "4.1.6",
-            "resolved":
-                "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
-            "integrity":
-                "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
-            "dev": true,
-            "requires": {
-                "babel-plugin-syntax-object-rest-spread": "^6.13.0",
-                "find-up": "^2.1.0",
-                "istanbul-lib-instrument": "^1.10.1",
-                "test-exclude": "^4.2.1"
-            }
-        },
         "babel-plugin-jest-hoist": {
-            "version": "23.2.0",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz",
-            "integrity": "sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc=",
-            "dev": true
-        },
-        "babel-plugin-syntax-object-rest-spread": {
-            "version": "6.13.0",
-            "resolved":
-                "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-            "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
-            "dev": true
+            "version": "24.6.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.6.0.tgz",
+            "integrity": "sha512-3pKNH6hMt9SbOv0F3WVmy5CWQ4uogS3k0GY5XLyQHJ9EGpAT9XWkFd2ZiXXtkwFHdAHa5j7w7kfxSP5lAIwu7w==",
+            "dev": true,
+            "requires": {
+                "@types/babel__traverse": "^7.0.6"
+            }
         },
         "babel-preset-jest": {
-            "version": "23.2.0",
-            "resolved":
-                "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz",
-            "integrity": "sha1-jsegOhOPABoaj7HoETZSvxpV2kY=",
+            "version": "24.6.0",
+            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz",
+            "integrity": "sha512-pdZqLEdmy1ZK5kyRUfvBb2IfTPb2BUvIJczlPspS8fWmBQslNNDBqVfh7BW5leOVJMDZKzjD8XEyABTk6gQ5yw==",
             "dev": true,
             "requires": {
-                "babel-plugin-jest-hoist": "^23.2.0",
-                "babel-plugin-syntax-object-rest-spread": "^6.13.0"
+                "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+                "babel-plugin-jest-hoist": "^24.6.0"
             }
-        },
-        "babel-register": {
-            "version": "6.26.0",
-            "resolved":
-                "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
-            "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-            "dev": true,
-            "requires": {
-                "babel-core": "^6.26.0",
-                "babel-runtime": "^6.26.0",
-                "core-js": "^2.5.0",
-                "home-or-tmp": "^2.0.0",
-                "lodash": "^4.17.4",
-                "mkdirp": "^0.5.1",
-                "source-map-support": "^0.4.15"
-            }
-        },
-        "babel-runtime": {
-            "version": "6.26.0",
-            "resolved":
-                "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-            "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-            "dev": true,
-            "requires": {
-                "core-js": "^2.4.0",
-                "regenerator-runtime": "^0.11.0"
-            }
-        },
-        "babel-template": {
-            "version": "6.26.0",
-            "resolved":
-                "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-            "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.26.0",
-                "babel-traverse": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "babylon": "^6.18.0",
-                "lodash": "^4.17.4"
-            }
-        },
-        "babel-traverse": {
-            "version": "6.26.0",
-            "resolved":
-                "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-            "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-            "dev": true,
-            "requires": {
-                "babel-code-frame": "^6.26.0",
-                "babel-messages": "^6.23.0",
-                "babel-runtime": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "babylon": "^6.18.0",
-                "debug": "^2.6.8",
-                "globals": "^9.18.0",
-                "invariant": "^2.2.2",
-                "lodash": "^4.17.4"
-            }
-        },
-        "babel-types": {
-            "version": "6.26.0",
-            "resolved":
-                "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-            "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.26.0",
-                "esutils": "^2.0.2",
-                "lodash": "^4.17.4",
-                "to-fast-properties": "^1.0.3"
-            }
-        },
-        "babylon": {
-            "version": "6.18.0",
-            "resolved":
-                "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-            "integrity":
-                "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-            "dev": true
         },
         "balanced-match": {
             "version": "1.0.0",
-            "resolved":
-                "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
             "dev": true
         },
         "base": {
             "version": "0.11.2",
             "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-            "integrity":
-                "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+            "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
             "dev": true,
             "requires": {
                 "cache-base": "^1.0.1",
@@ -898,8 +839,7 @@
             "dependencies": {
                 "define-property": {
                     "version": "1.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
@@ -908,10 +848,8 @@
                 },
                 "is-accessor-descriptor": {
                     "version": "1.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-                    "integrity":
-                        "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
@@ -919,10 +857,8 @@
                 },
                 "is-data-descriptor": {
                     "version": "1.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-                    "integrity":
-                        "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
@@ -930,38 +866,20 @@
                 },
                 "is-descriptor": {
                     "version": "1.0.2",
-                    "resolved":
-                        "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-                    "integrity":
-                        "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
                         "kind-of": "^6.0.2"
                     }
-                },
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved":
-                        "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
-                },
-                "kind-of": {
-                    "version": "6.0.2",
-                    "resolved":
-                        "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity":
-                        "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-                    "dev": true
                 }
             }
         },
         "bcrypt-pbkdf": {
             "version": "1.0.2",
-            "resolved":
-                "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
             "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
             "dev": true,
             "requires": {
@@ -970,10 +888,8 @@
         },
         "brace-expansion": {
             "version": "1.1.11",
-            "resolved":
-                "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity":
-                "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
@@ -981,39 +897,61 @@
             }
         },
         "braces": {
-            "version": "1.8.5",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-            "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+            "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
             "dev": true,
             "requires": {
-                "expand-range": "^1.8.1",
-                "preserve": "^0.2.0",
-                "repeat-element": "^1.1.2"
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
             }
         },
         "browser-process-hrtime": {
             "version": "0.1.3",
-            "resolved":
-                "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
-            "integrity":
-                "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
+            "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
+            "integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
             "dev": true
         },
         "browser-resolve": {
             "version": "1.11.3",
-            "resolved":
-                "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
-            "integrity":
-                "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+            "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+            "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
             "dev": true,
             "requires": {
                 "resolve": "1.1.7"
+            },
+            "dependencies": {
+                "resolve": {
+                    "version": "1.1.7",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+                    "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+                    "dev": true
+                }
             }
         },
         "bser": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
-            "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.0.tgz",
+            "integrity": "sha512-8zsjWrQkkBoLK6uxASk1nJ2SKv97ltiGDo6A3wA0/yRPz+CwmEyDo0hUrhIuukG2JHpAl3bvFIixw2/3Hi0DOg==",
             "dev": true,
             "requires": {
                 "node-int64": "^0.4.0"
@@ -1021,25 +959,14 @@
         },
         "buffer-from": {
             "version": "1.1.1",
-            "resolved":
-                "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-            "integrity":
-                "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-            "dev": true
-        },
-        "builtin-modules": {
-            "version": "1.1.1",
-            "resolved":
-                "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
             "dev": true
         },
         "cache-base": {
             "version": "1.0.1",
-            "resolved":
-                "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-            "integrity":
-                "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+            "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+            "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
             "dev": true,
             "requires": {
                 "collection-visit": "^1.0.0",
@@ -1051,53 +978,39 @@
                 "to-object-path": "^0.3.0",
                 "union-value": "^1.0.0",
                 "unset-value": "^1.0.0"
-            },
-            "dependencies": {
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved":
-                        "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
-                }
             }
         },
         "callsites": {
-            "version": "2.0.0",
-            "resolved":
-                "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-            "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
             "dev": true
         },
         "camelcase": {
-            "version": "4.1.0",
-            "resolved":
-                "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-            "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
             "dev": true
         },
         "capture-exit": {
-            "version": "1.2.0",
-            "resolved":
-                "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
-            "integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
+            "integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
             "dev": true,
             "requires": {
-                "rsvp": "^3.3.3"
+                "rsvp": "^4.8.4"
             }
         },
         "caseless": {
             "version": "0.12.0",
-            "resolved":
-                "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
             "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
             "dev": true
         },
         "chalk": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-            "integrity":
-                "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+            "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
             "dev": true,
             "requires": {
                 "ansi-styles": "^3.1.0",
@@ -1107,18 +1020,14 @@
         },
         "ci-info": {
             "version": "1.1.2",
-            "resolved":
-                "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
-            "integrity":
-                "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
+            "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
             "dev": true
         },
         "class-utils": {
             "version": "0.3.6",
-            "resolved":
-                "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-            "integrity":
-                "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+            "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+            "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
             "dev": true,
             "requires": {
                 "arr-union": "^3.1.0",
@@ -1129,33 +1038,41 @@
             "dependencies": {
                 "define-property": {
                     "version": "0.2.5",
-                    "resolved":
-                        "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
-                },
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved":
-                        "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
                 }
             }
         },
         "cliui": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-            "integrity":
-                "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+            "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
             "dev": true,
             "requires": {
                 "string-width": "^2.1.1",
                 "strip-ansi": "^4.0.0",
                 "wrap-ansi": "^2.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
             }
         },
         "co": {
@@ -1166,15 +1083,13 @@
         },
         "code-point-at": {
             "version": "1.1.0",
-            "resolved":
-                "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
             "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
             "dev": true
         },
         "collection-visit": {
             "version": "1.0.0",
-            "resolved":
-                "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
             "dev": true,
             "requires": {
@@ -1184,10 +1099,8 @@
         },
         "color-convert": {
             "version": "1.9.1",
-            "resolved":
-                "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-            "integrity":
-                "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+            "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
             "dev": true,
             "requires": {
                 "color-name": "^1.1.1"
@@ -1195,51 +1108,42 @@
         },
         "color-name": {
             "version": "1.1.3",
-            "resolved":
-                "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
             "dev": true
         },
         "combined-stream": {
-            "version": "1.0.7",
-            "resolved":
-                "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-            "integrity":
-                "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
             "dev": true,
             "requires": {
                 "delayed-stream": "~1.0.0"
             }
         },
         "commander": {
-            "version": "2.17.1",
-            "resolved":
-                "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-            "integrity":
-                "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+            "version": "2.20.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+            "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
             "dev": true,
             "optional": true
         },
         "component-emitter": {
-            "version": "1.2.1",
-            "resolved":
-                "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-            "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+            "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
             "dev": true
         },
         "concat-map": {
             "version": "0.0.1",
-            "resolved":
-                "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
         },
         "convert-source-map": {
             "version": "1.6.0",
-            "resolved":
-                "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
-            "integrity":
-                "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+            "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
             "dev": true,
             "requires": {
                 "safe-buffer": "~5.1.1"
@@ -1247,30 +1151,19 @@
         },
         "copy-descriptor": {
             "version": "0.1.1",
-            "resolved":
-                "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
             "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-            "dev": true
-        },
-        "core-js": {
-            "version": "2.5.7",
-            "resolved":
-                "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-            "integrity":
-                "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
             "dev": true
         },
         "core-util-is": {
             "version": "1.0.2",
-            "resolved":
-                "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
             "dev": true
         },
         "cross-spawn": {
             "version": "5.1.0",
-            "resolved":
-                "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
             "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
             "dev": true,
             "requires": {
@@ -1280,27 +1173,23 @@
             }
         },
         "cssom": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.4.tgz",
-            "integrity":
-                "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog==",
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
+            "integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
             "dev": true
         },
         "cssstyle": {
-            "version": "1.1.1",
-            "resolved":
-                "https://registry.npmjs.org/cssstyle/-/cssstyle-1.1.1.tgz",
-            "integrity":
-                "sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.3.0.tgz",
+            "integrity": "sha512-wXsoRfsRfsLVNaVzoKdqvEmK/5PFaEXNspVT22Ots6K/cnJdpoDKuQFw+qlMiXnmaif1OgeC466X1zISgAOcGg==",
             "dev": true,
             "requires": {
-                "cssom": "0.3.x"
+                "cssom": "~0.3.6"
             }
         },
         "dashdash": {
             "version": "1.14.1",
-            "resolved":
-                "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "dev": true,
             "requires": {
@@ -1309,10 +1198,8 @@
         },
         "data-urls": {
             "version": "1.1.0",
-            "resolved":
-                "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
-            "integrity":
-                "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+            "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
             "dev": true,
             "requires": {
                 "abab": "^2.0.0",
@@ -1322,10 +1209,8 @@
             "dependencies": {
                 "whatwg-url": {
                     "version": "7.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
-                    "integrity":
-                        "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+                    "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
                     "dev": true,
                     "requires": {
                         "lodash.sortby": "^4.7.0",
@@ -1338,8 +1223,7 @@
         "debug": {
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity":
-                "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
             "dev": true,
             "requires": {
                 "ms": "2.0.0"
@@ -1347,41 +1231,26 @@
         },
         "decamelize": {
             "version": "1.2.0",
-            "resolved":
-                "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
             "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
             "dev": true
         },
         "decode-uri-component": {
             "version": "0.2.0",
-            "resolved":
-                "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
             "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
             "dev": true
         },
         "deep-is": {
             "version": "0.1.3",
-            "resolved":
-                "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
             "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
             "dev": true
         },
-        "default-require-extensions": {
-            "version": "1.0.0",
-            "resolved":
-                "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-            "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
-            "dev": true,
-            "requires": {
-                "strip-bom": "^2.0.0"
-            }
-        },
         "define-properties": {
             "version": "1.1.3",
-            "resolved":
-                "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-            "integrity":
-                "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
             "dev": true,
             "requires": {
                 "object-keys": "^1.0.12"
@@ -1389,10 +1258,8 @@
         },
         "define-property": {
             "version": "2.0.2",
-            "resolved":
-                "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-            "integrity":
-                "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+            "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+            "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
             "dev": true,
             "requires": {
                 "is-descriptor": "^1.0.2",
@@ -1401,10 +1268,8 @@
             "dependencies": {
                 "is-accessor-descriptor": {
                     "version": "1.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-                    "integrity":
-                        "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
@@ -1412,10 +1277,8 @@
                 },
                 "is-data-descriptor": {
                     "version": "1.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-                    "integrity":
-                        "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
@@ -1423,71 +1286,39 @@
                 },
                 "is-descriptor": {
                     "version": "1.0.2",
-                    "resolved":
-                        "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-                    "integrity":
-                        "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
                         "kind-of": "^6.0.2"
                     }
-                },
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved":
-                        "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
-                },
-                "kind-of": {
-                    "version": "6.0.2",
-                    "resolved":
-                        "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity":
-                        "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-                    "dev": true
                 }
             }
         },
         "delayed-stream": {
             "version": "1.0.0",
-            "resolved":
-                "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
             "dev": true
         },
-        "detect-indent": {
-            "version": "4.0.0",
-            "resolved":
-                "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-            "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-            "dev": true,
-            "requires": {
-                "repeating": "^2.0.0"
-            }
-        },
         "detect-newline": {
             "version": "2.1.0",
-            "resolved":
-                "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
             "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
             "dev": true
         },
-        "diff": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-            "integrity":
-                "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+        "diff-sequences": {
+            "version": "24.3.0",
+            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.3.0.tgz",
+            "integrity": "sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==",
             "dev": true
         },
         "domexception": {
             "version": "1.0.1",
-            "resolved":
-                "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
-            "integrity":
-                "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+            "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+            "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
             "dev": true,
             "requires": {
                 "webidl-conversions": "^4.0.2"
@@ -1495,8 +1326,7 @@
         },
         "ecc-jsbn": {
             "version": "0.1.2",
-            "resolved":
-                "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
             "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
             "dev": true,
             "requires": {
@@ -1504,38 +1334,42 @@
                 "safer-buffer": "^2.1.0"
             }
         },
+        "end-of-stream": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+            "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+            "dev": true,
+            "requires": {
+                "once": "^1.4.0"
+            }
+        },
         "error-ex": {
             "version": "1.3.2",
-            "resolved":
-                "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-            "integrity":
-                "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
             "dev": true,
             "requires": {
                 "is-arrayish": "^0.2.1"
             }
         },
         "es-abstract": {
-            "version": "1.12.0",
-            "resolved":
-                "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
-            "integrity":
-                "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+            "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
             "dev": true,
             "requires": {
-                "es-to-primitive": "^1.1.1",
+                "es-to-primitive": "^1.2.0",
                 "function-bind": "^1.1.1",
-                "has": "^1.0.1",
-                "is-callable": "^1.1.3",
-                "is-regex": "^1.0.4"
+                "has": "^1.0.3",
+                "is-callable": "^1.1.4",
+                "is-regex": "^1.0.4",
+                "object-keys": "^1.0.12"
             }
         },
         "es-to-primitive": {
             "version": "1.2.0",
-            "resolved":
-                "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-            "integrity":
-                "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+            "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
             "dev": true,
             "requires": {
                 "is-callable": "^1.1.4",
@@ -1545,17 +1379,14 @@
         },
         "escape-string-regexp": {
             "version": "1.0.5",
-            "resolved":
-                "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
             "dev": true
         },
         "escodegen": {
-            "version": "1.11.0",
-            "resolved":
-                "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
-            "integrity":
-                "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
+            "integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
             "dev": true,
             "requires": {
                 "esprima": "^3.1.3",
@@ -1563,72 +1394,69 @@
                 "esutils": "^2.0.2",
                 "optionator": "^0.8.1",
                 "source-map": "~0.6.1"
-            },
-            "dependencies": {
-                "esprima": {
-                    "version": "3.1.3",
-                    "resolved":
-                        "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-                    "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-                    "dev": true
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved":
-                        "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity":
-                        "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true,
-                    "optional": true
-                }
             }
         },
         "esprima": {
-            "version": "4.0.1",
-            "resolved":
-                "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity":
-                "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+            "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
             "dev": true
         },
         "estraverse": {
             "version": "4.2.0",
-            "resolved":
-                "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
             "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
             "dev": true
         },
         "esutils": {
             "version": "2.0.2",
-            "resolved":
-                "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
             "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
             "dev": true
         },
         "exec-sh": {
-            "version": "0.2.2",
-            "resolved":
-                "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
-            "integrity":
-                "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
-            "dev": true,
-            "requires": {
-                "merge": "^1.2.0"
-            }
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.2.tgz",
+            "integrity": "sha512-9sLAvzhI5nc8TpuQUh4ahMdCrWT00wPWz7j47/emR5+2qEfoZP5zzUXvx+vdx+H6ohhnsYC31iX04QLYJK8zTg==",
+            "dev": true
         },
         "execa": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-            "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+            "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
             "dev": true,
             "requires": {
-                "cross-spawn": "^5.0.1",
-                "get-stream": "^3.0.0",
+                "cross-spawn": "^6.0.0",
+                "get-stream": "^4.0.0",
                 "is-stream": "^1.1.0",
                 "npm-run-path": "^2.0.0",
                 "p-finally": "^1.0.0",
                 "signal-exit": "^3.0.0",
                 "strip-eof": "^1.0.0"
+            },
+            "dependencies": {
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                    "dev": true,
+                    "requires": {
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "get-stream": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+                    "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                }
             }
         },
         "exit": {
@@ -1638,51 +1466,63 @@
             "dev": true
         },
         "expand-brackets": {
-            "version": "0.1.5",
-            "resolved":
-                "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-            "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+            "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
             "dev": true,
             "requires": {
-                "is-posix-bracket": "^0.1.0"
-            }
-        },
-        "expand-range": {
-            "version": "1.8.2",
-            "resolved":
-                "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-            "dev": true,
-            "requires": {
-                "fill-range": "^2.1.0"
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
             }
         },
         "expect": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/expect/-/expect-23.6.0.tgz",
-            "integrity":
-                "sha512-dgSoOHgmtn/aDGRVFWclQyPDKl2CQRq0hmIEoUAuQs/2rn2NcvCWcSCovm6BLeuB/7EZuLGu2QfnR+qRt5OM4w==",
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/expect/-/expect-24.8.0.tgz",
+            "integrity": "sha512-/zYvP8iMDrzaaxHVa724eJBCKqSHmO0FA7EDkBiRHxg6OipmMn1fN+C8T9L9K8yr7UONkOifu6+LLH+z76CnaA==",
             "dev": true,
             "requires": {
+                "@jest/types": "^24.8.0",
                 "ansi-styles": "^3.2.0",
-                "jest-diff": "^23.6.0",
-                "jest-get-type": "^22.1.0",
-                "jest-matcher-utils": "^23.6.0",
-                "jest-message-util": "^23.4.0",
-                "jest-regex-util": "^23.3.0"
+                "jest-get-type": "^24.8.0",
+                "jest-matcher-utils": "^24.8.0",
+                "jest-message-util": "^24.8.0",
+                "jest-regex-util": "^24.3.0"
             }
         },
         "extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity":
-                "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
             "dev": true
         },
         "extend-shallow": {
             "version": "3.0.2",
-            "resolved":
-                "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
             "dev": true,
             "requires": {
@@ -1692,10 +1532,8 @@
             "dependencies": {
                 "is-extendable": {
                     "version": "1.0.1",
-                    "resolved":
-                        "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-                    "integrity":
-                        "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
                         "is-plain-object": "^2.0.4"
@@ -1704,90 +1542,129 @@
             }
         },
         "extglob": {
-            "version": "0.3.2",
-            "resolved":
-                "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-            "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+            "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
             "dev": true,
             "requires": {
-                "is-extglob": "^1.0.0"
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^1.0.0"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                }
             }
         },
         "extsprintf": {
             "version": "1.3.0",
-            "resolved":
-                "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
             "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
             "dev": true
         },
         "fast-deep-equal": {
-            "version": "1.1.0",
-            "resolved":
-                "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+            "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
             "dev": true
         },
         "fast-json-stable-stringify": {
             "version": "2.0.0",
-            "resolved":
-                "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
             "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
             "dev": true
         },
         "fast-levenshtein": {
             "version": "2.0.6",
-            "resolved":
-                "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
         },
         "fb-watchman": {
             "version": "2.0.0",
-            "resolved":
-                "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
             "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
             "dev": true,
             "requires": {
                 "bser": "^2.0.0"
             }
         },
-        "filename-regex": {
-            "version": "2.0.1",
-            "resolved":
-                "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-            "dev": true
-        },
-        "fileset": {
-            "version": "2.0.3",
-            "resolved":
-                "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
-            "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
-            "dev": true,
-            "requires": {
-                "glob": "^7.0.3",
-                "minimatch": "^3.0.3"
-            }
-        },
         "fill-range": {
-            "version": "2.2.4",
-            "resolved":
-                "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-            "integrity":
-                "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+            "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
             "dev": true,
             "requires": {
-                "is-number": "^2.1.0",
-                "isobject": "^2.0.0",
-                "randomatic": "^3.0.0",
-                "repeat-element": "^1.1.2",
-                "repeat-string": "^1.5.2"
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
             }
         },
         "find-up": {
             "version": "2.1.0",
-            "resolved":
-                "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
             "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
             "dev": true,
             "requires": {
@@ -1795,21 +1672,17 @@
             }
         },
         "follow-redirects": {
-            "version": "1.4.0",
-            "resolved":
-                "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.0.tgz",
-            "integrity":
-                "sha512-SLUmsiaGeQa2qgJJzJgHpQ6lARP3uyVr0SkMryJmoE86XvUeM7RkYD5FT0rNyjCV5zHlNUpcp3l/6oUkqMEOqg==",
+            "version": "1.5.10",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+            "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
             "requires": {
-                "debug": "^3.1.0"
+                "debug": "=3.1.0"
             },
             "dependencies": {
                 "debug": {
                     "version": "3.1.0",
-                    "resolved":
-                        "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity":
-                        "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -1822,29 +1695,16 @@
             "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
             "dev": true
         },
-        "for-own": {
-            "version": "0.1.5",
-            "resolved":
-                "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-            "dev": true,
-            "requires": {
-                "for-in": "^1.0.1"
-            }
-        },
         "forever-agent": {
             "version": "0.6.1",
-            "resolved":
-                "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
             "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
             "dev": true
         },
         "form-data": {
             "version": "2.3.3",
-            "resolved":
-                "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-            "integrity":
-                "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
             "dev": true,
             "requires": {
                 "asynckit": "^0.4.0",
@@ -1854,8 +1714,7 @@
         },
         "fragment-cache": {
             "version": "0.2.1",
-            "resolved":
-                "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+            "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
             "dev": true,
             "requires": {
@@ -1864,22 +1723,19 @@
         },
         "fs.realpath": {
             "version": "1.0.0",
-            "resolved":
-                "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
             "dev": true
         },
         "fsevents": {
-            "version": "1.2.4",
-            "resolved":
-                "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-            "integrity":
-                "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+            "version": "1.2.9",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+            "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
             "dev": true,
             "optional": true,
             "requires": {
-                "nan": "^2.9.2",
-                "node-pre-gyp": "^0.10.0"
+                "nan": "^2.12.1",
+                "node-pre-gyp": "^0.12.0"
             },
             "dependencies": {
                 "abbrev": {
@@ -1891,7 +1747,8 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -1900,7 +1757,7 @@
                     "optional": true
                 },
                 "are-we-there-yet": {
-                    "version": "1.1.4",
+                    "version": "1.1.5",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -1912,19 +1769,21 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
                     }
                 },
                 "chownr": {
-                    "version": "1.0.1",
+                    "version": "1.1.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true
@@ -1932,17 +1791,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -1951,16 +1813,16 @@
                     "optional": true
                 },
                 "debug": {
-                    "version": "2.6.9",
+                    "version": "4.1.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "ms": "2.0.0"
+                        "ms": "^2.1.1"
                     }
                 },
                 "deep-extend": {
-                    "version": "0.5.1",
+                    "version": "0.6.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true
@@ -2009,7 +1871,7 @@
                     }
                 },
                 "glob": {
-                    "version": "7.1.2",
+                    "version": "7.1.3",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -2029,12 +1891,12 @@
                     "optional": true
                 },
                 "iconv-lite": {
-                    "version": "0.4.21",
+                    "version": "0.4.24",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safer-buffer": "^2.1.0"
+                        "safer-buffer": ">= 2.1.2 < 3"
                     }
                 },
                 "ignore-walk": {
@@ -2059,7 +1921,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -2071,6 +1934,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -2085,6 +1949,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -2092,19 +1957,21 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
-                    "version": "2.2.4",
+                    "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
-                        "safe-buffer": "^5.1.1",
+                        "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
                     }
                 },
                 "minizlib": {
-                    "version": "1.1.0",
+                    "version": "1.2.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -2116,40 +1983,41 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
                 },
                 "ms": {
-                    "version": "2.0.0",
+                    "version": "2.1.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "needle": {
-                    "version": "2.2.0",
+                    "version": "2.3.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "debug": "^2.1.2",
+                        "debug": "^4.1.0",
                         "iconv-lite": "^0.4.4",
                         "sax": "^1.2.4"
                     }
                 },
                 "node-pre-gyp": {
-                    "version": "0.10.0",
+                    "version": "0.12.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
                         "detect-libc": "^1.0.2",
                         "mkdirp": "^0.5.1",
-                        "needle": "^2.2.0",
+                        "needle": "^2.2.1",
                         "nopt": "^4.0.1",
                         "npm-packlist": "^1.1.6",
                         "npmlog": "^4.0.2",
-                        "rc": "^1.1.7",
+                        "rc": "^1.2.7",
                         "rimraf": "^2.6.1",
                         "semver": "^5.3.0",
                         "tar": "^4"
@@ -2166,13 +2034,13 @@
                     }
                 },
                 "npm-bundled": {
-                    "version": "1.0.3",
+                    "version": "1.0.6",
                     "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "npm-packlist": {
-                    "version": "1.1.10",
+                    "version": "1.4.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -2196,7 +2064,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -2208,6 +2077,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -2247,12 +2117,12 @@
                     "optional": true
                 },
                 "rc": {
-                    "version": "1.2.7",
+                    "version": "1.2.8",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "deep-extend": "^0.5.1",
+                        "deep-extend": "^0.6.0",
                         "ini": "~1.3.0",
                         "minimist": "^1.2.0",
                         "strip-json-comments": "~2.0.1"
@@ -2282,18 +2152,19 @@
                     }
                 },
                 "rimraf": {
-                    "version": "2.6.2",
+                    "version": "2.6.3",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "glob": "^7.0.5"
+                        "glob": "^7.1.3"
                     }
                 },
                 "safe-buffer": {
-                    "version": "5.1.1",
+                    "version": "5.1.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -2308,7 +2179,7 @@
                     "optional": true
                 },
                 "semver": {
-                    "version": "5.5.0",
+                    "version": "5.7.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true
@@ -2329,6 +2200,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -2348,6 +2220,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -2359,17 +2232,17 @@
                     "optional": true
                 },
                 "tar": {
-                    "version": "4.4.1",
+                    "version": "4.4.8",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "chownr": "^1.0.1",
+                        "chownr": "^1.1.1",
                         "fs-minipass": "^1.2.5",
-                        "minipass": "^2.2.4",
-                        "minizlib": "^1.1.0",
+                        "minipass": "^2.3.4",
+                        "minizlib": "^1.1.1",
                         "mkdirp": "^0.5.0",
-                        "safe-buffer": "^5.1.1",
+                        "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.2"
                     }
                 },
@@ -2380,60 +2253,55 @@
                     "optional": true
                 },
                 "wide-align": {
-                    "version": "1.1.2",
+                    "version": "1.1.3",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "string-width": "^1.0.2"
+                        "string-width": "^1.0.2 || 2"
                     }
                 },
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
-                    "version": "3.0.2",
+                    "version": "3.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
         "function-bind": {
             "version": "1.1.1",
-            "resolved":
-                "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity":
-                "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
             "dev": true
         },
         "get-caller-file": {
             "version": "1.0.3",
-            "resolved":
-                "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-            "integrity":
-                "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+            "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
             "dev": true
         },
         "get-stream": {
             "version": "3.0.0",
-            "resolved":
-                "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
             "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
             "dev": true
         },
         "get-value": {
             "version": "2.0.6",
-            "resolved":
-                "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+            "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
             "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
             "dev": true
         },
         "getpass": {
             "version": "0.1.7",
-            "resolved":
-                "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "dev": true,
             "requires": {
@@ -2441,10 +2309,9 @@
             }
         },
         "glob": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-            "integrity":
-                "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+            "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
             "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
@@ -2455,40 +2322,16 @@
                 "path-is-absolute": "^1.0.0"
             }
         },
-        "glob-base": {
-            "version": "0.3.0",
-            "resolved":
-                "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-            "dev": true,
-            "requires": {
-                "glob-parent": "^2.0.0",
-                "is-glob": "^2.0.0"
-            }
-        },
-        "glob-parent": {
-            "version": "2.0.0",
-            "resolved":
-                "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-            "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-            "dev": true,
-            "requires": {
-                "is-glob": "^2.0.0"
-            }
-        },
         "globals": {
-            "version": "9.18.0",
-            "resolved":
-                "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-            "integrity":
-                "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+            "version": "11.12.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
             "dev": true
         },
         "graceful-fs": {
-            "version": "4.1.11",
-            "resolved":
-                "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
+            "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
             "dev": true
         },
         "growly": {
@@ -2498,107 +2341,68 @@
             "dev": true
         },
         "handlebars": {
-            "version": "4.0.12",
-            "resolved":
-                "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
-            "integrity":
-                "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+            "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
             "dev": true,
             "requires": {
-                "async": "^2.5.0",
+                "neo-async": "^2.6.0",
                 "optimist": "^0.6.1",
                 "source-map": "^0.6.1",
                 "uglify-js": "^3.1.4"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved":
-                        "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity":
-                        "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                }
             }
         },
         "har-schema": {
             "version": "2.0.0",
-            "resolved":
-                "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
             "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
             "dev": true
         },
         "har-validator": {
-            "version": "5.1.0",
-            "resolved":
-                "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
-            "integrity":
-                "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+            "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
             "dev": true,
             "requires": {
-                "ajv": "^5.3.0",
+                "ajv": "^6.5.5",
                 "har-schema": "^2.0.0"
             }
         },
         "has": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-            "integrity":
-                "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
             "dev": true,
             "requires": {
                 "function-bind": "^1.1.1"
             }
         },
-        "has-ansi": {
-            "version": "2.0.0",
-            "resolved":
-                "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-            "dev": true,
-            "requires": {
-                "ansi-regex": "^2.0.0"
-            }
-        },
         "has-flag": {
             "version": "2.0.0",
-            "resolved":
-                "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
             "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
             "dev": true
         },
         "has-symbols": {
             "version": "1.0.0",
-            "resolved":
-                "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
             "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
             "dev": true
         },
         "has-value": {
             "version": "1.0.0",
-            "resolved":
-                "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
             "dev": true,
             "requires": {
                 "get-value": "^2.0.6",
                 "has-values": "^1.0.0",
                 "isobject": "^3.0.0"
-            },
-            "dependencies": {
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved":
-                        "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
-                }
             }
         },
         "has-values": {
             "version": "1.0.0",
-            "resolved":
-                "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
             "dev": true,
             "requires": {
@@ -2606,32 +2410,9 @@
                 "kind-of": "^4.0.0"
             },
             "dependencies": {
-                "is-number": {
-                    "version": "3.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved":
-                                "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "dev": true,
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
-                    }
-                },
                 "kind-of": {
                     "version": "4.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
@@ -2641,37 +2422,21 @@
             }
         },
         "hoek": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
-            "integrity":
-                "sha512-Bmr56pxML1c9kU+NS51SMFkiVQAb+9uFfXwyqR2tn4w2FPvmPt65eZ9aCcEfRXd9G74HkZnILC6p967pED4aiw==",
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
+            "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w==",
             "dev": true
-        },
-        "home-or-tmp": {
-            "version": "2.0.0",
-            "resolved":
-                "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-            "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-            "dev": true,
-            "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.1"
-            }
         },
         "hosted-git-info": {
             "version": "2.7.1",
-            "resolved":
-                "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-            "integrity":
-                "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+            "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
             "dev": true
         },
         "html-encoding-sniffer": {
             "version": "1.0.2",
-            "resolved":
-                "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
-            "integrity":
-                "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+            "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
             "dev": true,
             "requires": {
                 "whatwg-encoding": "^1.0.1"
@@ -2679,8 +2444,7 @@
         },
         "http-signature": {
             "version": "1.2.0",
-            "resolved":
-                "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "dev": true,
             "requires": {
@@ -2692,8 +2456,7 @@
         "husky": {
             "version": "0.14.3",
             "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
-            "integrity":
-                "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+            "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
             "dev": true,
             "requires": {
                 "is-ci": "^1.0.10",
@@ -2703,8 +2466,7 @@
             "dependencies": {
                 "normalize-path": {
                     "version": "1.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
                     "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
                     "dev": true
                 }
@@ -2712,45 +2474,38 @@
         },
         "iconv-lite": {
             "version": "0.4.24",
-            "resolved":
-                "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-            "integrity":
-                "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
             "dev": true,
             "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
             }
         },
         "ignore": {
-            "version": "3.3.8",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
-            "integrity":
-                "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg==",
+            "version": "3.3.10",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+            "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
             "dev": true
         },
         "import-local": {
-            "version": "1.0.0",
-            "resolved":
-                "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
-            "integrity":
-                "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+            "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
             "dev": true,
             "requires": {
-                "pkg-dir": "^2.0.0",
+                "pkg-dir": "^3.0.0",
                 "resolve-cwd": "^2.0.0"
             }
         },
         "imurmurhash": {
             "version": "0.1.4",
-            "resolved":
-                "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
             "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
             "dev": true
         },
         "inflight": {
             "version": "1.0.6",
-            "resolved":
-                "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
@@ -2759,77 +2514,68 @@
             }
         },
         "inherits": {
-            "version": "2.0.3",
-            "resolved":
-                "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
         },
         "invariant": {
             "version": "2.2.4",
-            "resolved":
-                "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-            "integrity":
-                "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
             "dev": true,
             "requires": {
                 "loose-envify": "^1.0.0"
             }
         },
         "invert-kv": {
-            "version": "1.0.0",
-            "resolved":
-                "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+            "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
             "dev": true
         },
         "is-accessor-descriptor": {
             "version": "0.1.6",
-            "resolved":
-                "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
             "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
             }
         },
         "is-arrayish": {
             "version": "0.2.1",
-            "resolved":
-                "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
             "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
             "dev": true
         },
         "is-buffer": {
             "version": "1.1.6",
-            "resolved":
-                "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity":
-                "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-        },
-        "is-builtin-module": {
-            "version": "1.0.0",
-            "resolved":
-                "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-            "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-            "dev": true,
-            "requires": {
-                "builtin-modules": "^1.0.0"
-            }
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+            "dev": true
         },
         "is-callable": {
             "version": "1.1.4",
-            "resolved":
-                "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-            "integrity":
-                "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+            "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
             "dev": true
         },
         "is-ci": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
-            "integrity":
-                "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+            "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
             "dev": true,
             "requires": {
                 "ci-info": "^1.0.0"
@@ -2837,27 +2583,34 @@
         },
         "is-data-descriptor": {
             "version": "0.1.4",
-            "resolved":
-                "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+            "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
             "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
             }
         },
         "is-date-object": {
             "version": "1.0.1",
-            "resolved":
-                "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
             "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
             "dev": true
         },
         "is-descriptor": {
             "version": "0.1.6",
-            "resolved":
-                "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-            "integrity":
-                "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+            "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+            "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
             "dev": true,
             "requires": {
                 "is-accessor-descriptor": "^0.1.6",
@@ -2867,127 +2620,62 @@
             "dependencies": {
                 "kind-of": {
                     "version": "5.1.0",
-                    "resolved":
-                        "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                    "integrity":
-                        "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
                     "dev": true
                 }
-            }
-        },
-        "is-dotfile": {
-            "version": "1.0.3",
-            "resolved":
-                "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-            "dev": true
-        },
-        "is-equal-shallow": {
-            "version": "0.1.3",
-            "resolved":
-                "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-            "dev": true,
-            "requires": {
-                "is-primitive": "^2.0.0"
             }
         },
         "is-extendable": {
             "version": "0.1.1",
-            "resolved":
-                "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
             "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
             "dev": true
         },
-        "is-extglob": {
-            "version": "1.0.0",
-            "resolved":
-                "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-            "dev": true
-        },
-        "is-finite": {
-            "version": "1.0.2",
-            "resolved":
-                "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-            "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-            "dev": true,
-            "requires": {
-                "number-is-nan": "^1.0.0"
-            }
-        },
         "is-fullwidth-code-point": {
             "version": "2.0.0",
-            "resolved":
-                "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
             "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
             "dev": true
         },
         "is-generator-fn": {
-            "version": "1.0.0",
-            "resolved":
-                "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
-            "integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+            "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
             "dev": true
         },
-        "is-glob": {
-            "version": "2.0.1",
-            "resolved":
-                "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-            "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-            "dev": true,
-            "requires": {
-                "is-extglob": "^1.0.0"
-            }
-        },
         "is-number": {
-            "version": "2.1.0",
-            "resolved":
-                "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-            "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+            "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
             "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
             }
         },
         "is-plain-object": {
             "version": "2.0.4",
-            "resolved":
-                "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-            "integrity":
-                "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+            "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
             "requires": {
                 "isobject": "^3.0.1"
-            },
-            "dependencies": {
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved":
-                        "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
-                }
             }
-        },
-        "is-posix-bracket": {
-            "version": "0.1.1",
-            "resolved":
-                "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-            "dev": true
-        },
-        "is-primitive": {
-            "version": "2.0.0",
-            "resolved":
-                "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-            "dev": true
         },
         "is-regex": {
             "version": "1.0.4",
-            "resolved":
-                "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
             "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
             "dev": true,
             "requires": {
@@ -2996,17 +2684,14 @@
         },
         "is-stream": {
             "version": "1.1.0",
-            "resolved":
-                "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
             "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
             "dev": true
         },
         "is-symbol": {
             "version": "1.0.2",
-            "resolved":
-                "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-            "integrity":
-                "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+            "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
             "dev": true,
             "requires": {
                 "has-symbols": "^1.0.0"
@@ -3014,30 +2699,25 @@
         },
         "is-typedarray": {
             "version": "1.0.0",
-            "resolved":
-                "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
             "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-            "dev": true
-        },
-        "is-utf8": {
-            "version": "0.2.1",
-            "resolved":
-                "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
             "dev": true
         },
         "is-windows": {
             "version": "1.0.2",
-            "resolved":
-                "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-            "integrity":
-                "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+            "dev": true
+        },
+        "is-wsl": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+            "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
             "dev": true
         },
         "isarray": {
             "version": "1.0.0",
-            "resolved":
-                "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
             "dev": true
         },
@@ -3048,629 +2728,609 @@
             "dev": true
         },
         "isobject": {
-            "version": "2.1.0",
-            "resolved":
-                "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-            "dev": true,
-            "requires": {
-                "isarray": "1.0.0"
-            }
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+            "dev": true
         },
         "isstream": {
             "version": "0.1.2",
-            "resolved":
-                "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
             "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
             "dev": true
         },
-        "istanbul-api": {
-            "version": "1.3.7",
-            "resolved":
-                "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.7.tgz",
-            "integrity":
-                "sha512-4/ApBnMVeEPG3EkSzcw25wDe4N66wxwn+KKn6b47vyek8Xb3NBAcg4xfuQbS7BqcZuTX4wxfD5lVagdggR3gyA==",
-            "dev": true,
-            "requires": {
-                "async": "^2.1.4",
-                "fileset": "^2.0.2",
-                "istanbul-lib-coverage": "^1.2.1",
-                "istanbul-lib-hook": "^1.2.2",
-                "istanbul-lib-instrument": "^1.10.2",
-                "istanbul-lib-report": "^1.1.5",
-                "istanbul-lib-source-maps": "^1.2.6",
-                "istanbul-reports": "^1.5.1",
-                "js-yaml": "^3.7.0",
-                "mkdirp": "^0.5.1",
-                "once": "^1.4.0"
-            }
-        },
         "istanbul-lib-coverage": {
-            "version": "1.2.1",
-            "resolved":
-                "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz",
-            "integrity":
-                "sha512-PzITeunAgyGbtY1ibVIUiV679EFChHjoMNRibEIobvmrCRaIgwLxNucOSimtNWUhEib/oO7QY2imD75JVgCJWQ==",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+            "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
             "dev": true
         },
-        "istanbul-lib-hook": {
-            "version": "1.2.2",
-            "resolved":
-                "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.2.tgz",
-            "integrity":
-                "sha512-/Jmq7Y1VeHnZEQ3TL10VHyb564mn6VrQXHchON9Jf/AEcmQ3ZIiyD1BVzNOKTZf/G3gE+kiGK6SmpF9y3qGPLw==",
-            "dev": true,
-            "requires": {
-                "append-transform": "^0.4.0"
-            }
-        },
         "istanbul-lib-instrument": {
-            "version": "1.10.2",
-            "resolved":
-                "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.2.tgz",
-            "integrity":
-                "sha512-aWHxfxDqvh/ZlxR8BBaEPVSWDPUkGD63VjGQn3jcw8jCp7sHEMKcrj4xfJn/ABzdMEHiQNyvDQhqm5o8+SQg7A==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+            "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
             "dev": true,
             "requires": {
-                "babel-generator": "^6.18.0",
-                "babel-template": "^6.16.0",
-                "babel-traverse": "^6.18.0",
-                "babel-types": "^6.18.0",
-                "babylon": "^6.18.0",
-                "istanbul-lib-coverage": "^1.2.1",
-                "semver": "^5.3.0"
+                "@babel/generator": "^7.4.0",
+                "@babel/parser": "^7.4.3",
+                "@babel/template": "^7.4.0",
+                "@babel/traverse": "^7.4.3",
+                "@babel/types": "^7.4.0",
+                "istanbul-lib-coverage": "^2.0.5",
+                "semver": "^6.0.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.2.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
+                    "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==",
+                    "dev": true
+                }
             }
         },
         "istanbul-lib-report": {
-            "version": "1.1.5",
-            "resolved":
-                "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.5.tgz",
-            "integrity":
-                "sha512-UsYfRMoi6QO/doUshYNqcKJqVmFe9w51GZz8BS3WB0lYxAllQYklka2wP9+dGZeHYaWIdcXUx8JGdbqaoXRXzw==",
+            "version": "2.0.8",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+            "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
             "dev": true,
             "requires": {
-                "istanbul-lib-coverage": "^1.2.1",
-                "mkdirp": "^0.5.1",
-                "path-parse": "^1.0.5",
-                "supports-color": "^3.1.2"
+                "istanbul-lib-coverage": "^2.0.5",
+                "make-dir": "^2.1.0",
+                "supports-color": "^6.1.0"
             },
             "dependencies": {
                 "has-flag": {
-                    "version": "1.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "3.2.3",
-                    "resolved":
-                        "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^1.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
         },
         "istanbul-lib-source-maps": {
-            "version": "1.2.6",
-            "resolved":
-                "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.6.tgz",
-            "integrity":
-                "sha512-TtbsY5GIHgbMsMiRw35YBHGpZ1DVFEO19vxxeiDMYaeOFOCzfnYVxvl6pOUIZR4dtPhAGpSMup8OyF8ubsaqEg==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+            "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
             "dev": true,
             "requires": {
-                "debug": "^3.1.0",
-                "istanbul-lib-coverage": "^1.2.1",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.6.1",
-                "source-map": "^0.5.3"
+                "debug": "^4.1.1",
+                "istanbul-lib-coverage": "^2.0.5",
+                "make-dir": "^2.1.0",
+                "rimraf": "^2.6.3",
+                "source-map": "^0.6.1"
             },
             "dependencies": {
                 "debug": {
-                    "version": "3.2.6",
-                    "resolved":
-                        "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-                    "integrity":
-                        "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
                     "dev": true,
                     "requires": {
                         "ms": "^2.1.1"
                     }
                 },
                 "ms": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-                    "integrity":
-                        "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
                     "dev": true
                 }
             }
         },
         "istanbul-reports": {
-            "version": "1.5.1",
-            "resolved":
-                "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.5.1.tgz",
-            "integrity":
-                "sha512-+cfoZ0UXzWjhAdzosCPP3AN8vvef8XDkWtTfgaN+7L3YTpNYITnCaEkceo5SEYy644VkHka/P1FvkWvrG/rrJw==",
+            "version": "2.2.6",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
+            "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
             "dev": true,
             "requires": {
-                "handlebars": "^4.0.3"
+                "handlebars": "^4.1.2"
             }
         },
         "jest": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/jest/-/jest-23.6.0.tgz",
-            "integrity":
-                "sha512-lWzcd+HSiqeuxyhG+EnZds6iO3Y3ZEnMrfZq/OTGvF/C+Z4fPMCdhWTGSAiO2Oym9rbEXfwddHhh6jqrTF3+Lw==",
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest/-/jest-24.8.0.tgz",
+            "integrity": "sha512-o0HM90RKFRNWmAWvlyV8i5jGZ97pFwkeVoGvPW1EtLTgJc2+jcuqcbbqcSZLE/3f2S5pt0y2ZBETuhpWNl1Reg==",
             "dev": true,
             "requires": {
-                "import-local": "^1.0.0",
-                "jest-cli": "^23.6.0"
+                "import-local": "^2.0.0",
+                "jest-cli": "^24.8.0"
             },
             "dependencies": {
-                "jest-cli": {
-                    "version": "23.6.0",
-                    "resolved":
-                        "https://registry.npmjs.org/jest-cli/-/jest-cli-23.6.0.tgz",
-                    "integrity":
-                        "sha512-hgeD1zRUp1E1zsiyOXjEn4LzRLWdJBV//ukAHGlx6s5mfCNJTbhbHjgxnDUXA8fsKWN/HqFFF6X5XcCwC/IvYQ==",
+                "ci-info": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+                    "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+                    "dev": true
+                },
+                "is-ci": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+                    "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
                     "dev": true,
                     "requires": {
-                        "ansi-escapes": "^3.0.0",
+                        "ci-info": "^2.0.0"
+                    }
+                },
+                "jest-cli": {
+                    "version": "24.8.0",
+                    "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.8.0.tgz",
+                    "integrity": "sha512-+p6J00jSMPQ116ZLlHJJvdf8wbjNbZdeSX9ptfHX06/MSNaXmKihQzx5vQcw0q2G6JsdVkUIdWbOWtSnaYs3yA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/core": "^24.8.0",
+                        "@jest/test-result": "^24.8.0",
+                        "@jest/types": "^24.8.0",
                         "chalk": "^2.0.1",
                         "exit": "^0.1.2",
-                        "glob": "^7.1.2",
-                        "graceful-fs": "^4.1.11",
-                        "import-local": "^1.0.0",
-                        "is-ci": "^1.0.10",
-                        "istanbul-api": "^1.3.1",
-                        "istanbul-lib-coverage": "^1.2.0",
-                        "istanbul-lib-instrument": "^1.10.1",
-                        "istanbul-lib-source-maps": "^1.2.4",
-                        "jest-changed-files": "^23.4.2",
-                        "jest-config": "^23.6.0",
-                        "jest-environment-jsdom": "^23.4.0",
-                        "jest-get-type": "^22.1.0",
-                        "jest-haste-map": "^23.6.0",
-                        "jest-message-util": "^23.4.0",
-                        "jest-regex-util": "^23.3.0",
-                        "jest-resolve-dependencies": "^23.6.0",
-                        "jest-runner": "^23.6.0",
-                        "jest-runtime": "^23.6.0",
-                        "jest-snapshot": "^23.6.0",
-                        "jest-util": "^23.4.0",
-                        "jest-validate": "^23.6.0",
-                        "jest-watcher": "^23.4.0",
-                        "jest-worker": "^23.2.0",
-                        "micromatch": "^2.3.11",
-                        "node-notifier": "^5.2.1",
-                        "prompts": "^0.1.9",
-                        "realpath-native": "^1.0.0",
-                        "rimraf": "^2.5.4",
-                        "slash": "^1.0.0",
-                        "string-length": "^2.0.0",
-                        "strip-ansi": "^4.0.0",
-                        "which": "^1.2.12",
-                        "yargs": "^11.0.0"
+                        "import-local": "^2.0.0",
+                        "is-ci": "^2.0.0",
+                        "jest-config": "^24.8.0",
+                        "jest-util": "^24.8.0",
+                        "jest-validate": "^24.8.0",
+                        "prompts": "^2.0.1",
+                        "realpath-native": "^1.1.0",
+                        "yargs": "^12.0.2"
                     }
                 }
             }
         },
         "jest-changed-files": {
-            "version": "23.4.2",
-            "resolved":
-                "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-23.4.2.tgz",
-            "integrity":
-                "sha512-EyNhTAUWEfwnK0Is/09LxoqNDOn7mU7S3EHskG52djOFS/z+IT0jT3h3Ql61+dklcG7bJJitIWEMB4Sp1piHmA==",
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.8.0.tgz",
+            "integrity": "sha512-qgANC1Yrivsq+UrLXsvJefBKVoCsKB0Hv+mBb6NMjjZ90wwxCDmU3hsCXBya30cH+LnPYjwgcU65i6yJ5Nfuug==",
             "dev": true,
             "requires": {
+                "@jest/types": "^24.8.0",
+                "execa": "^1.0.0",
                 "throat": "^4.0.0"
             }
         },
         "jest-config": {
-            "version": "23.6.0",
-            "resolved":
-                "https://registry.npmjs.org/jest-config/-/jest-config-23.6.0.tgz",
-            "integrity":
-                "sha512-i8V7z9BeDXab1+VNo78WM0AtWpBRXJLnkT+lyT+Slx/cbP5sZJ0+NDuLcmBE5hXAoK0aUp7vI+MOxR+R4d8SRQ==",
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.8.0.tgz",
+            "integrity": "sha512-Czl3Nn2uEzVGsOeaewGWoDPD8GStxCpAe0zOYs2x2l0fZAgPbCr3uwUkgNKV3LwE13VXythM946cd5rdGkkBZw==",
             "dev": true,
             "requires": {
-                "babel-core": "^6.0.0",
-                "babel-jest": "^23.6.0",
+                "@babel/core": "^7.1.0",
+                "@jest/test-sequencer": "^24.8.0",
+                "@jest/types": "^24.8.0",
+                "babel-jest": "^24.8.0",
                 "chalk": "^2.0.1",
                 "glob": "^7.1.1",
-                "jest-environment-jsdom": "^23.4.0",
-                "jest-environment-node": "^23.4.0",
-                "jest-get-type": "^22.1.0",
-                "jest-jasmine2": "^23.6.0",
-                "jest-regex-util": "^23.3.0",
-                "jest-resolve": "^23.6.0",
-                "jest-util": "^23.4.0",
-                "jest-validate": "^23.6.0",
-                "micromatch": "^2.3.11",
-                "pretty-format": "^23.6.0"
+                "jest-environment-jsdom": "^24.8.0",
+                "jest-environment-node": "^24.8.0",
+                "jest-get-type": "^24.8.0",
+                "jest-jasmine2": "^24.8.0",
+                "jest-regex-util": "^24.3.0",
+                "jest-resolve": "^24.8.0",
+                "jest-util": "^24.8.0",
+                "jest-validate": "^24.8.0",
+                "micromatch": "^3.1.10",
+                "pretty-format": "^24.8.0",
+                "realpath-native": "^1.1.0"
             }
         },
         "jest-diff": {
-            "version": "23.6.0",
-            "resolved":
-                "https://registry.npmjs.org/jest-diff/-/jest-diff-23.6.0.tgz",
-            "integrity":
-                "sha512-Gz9l5Ov+X3aL5L37IT+8hoCUsof1CVYBb2QEkOupK64XyRR3h+uRpYIm97K7sY8diFxowR8pIGEdyfMKTixo3g==",
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.8.0.tgz",
+            "integrity": "sha512-wxetCEl49zUpJ/bvUmIFjd/o52J+yWcoc5ZyPq4/W1LUKGEhRYDIbP1KcF6t+PvqNrGAFk4/JhtxDq/Nnzs66g==",
             "dev": true,
             "requires": {
                 "chalk": "^2.0.1",
-                "diff": "^3.2.0",
-                "jest-get-type": "^22.1.0",
-                "pretty-format": "^23.6.0"
+                "diff-sequences": "^24.3.0",
+                "jest-get-type": "^24.8.0",
+                "pretty-format": "^24.8.0"
             }
         },
         "jest-docblock": {
-            "version": "23.2.0",
-            "resolved":
-                "https://registry.npmjs.org/jest-docblock/-/jest-docblock-23.2.0.tgz",
-            "integrity": "sha1-8IXh8YVI2Z/dabICB+b9VdkTg6c=",
+            "version": "24.3.0",
+            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.3.0.tgz",
+            "integrity": "sha512-nlANmF9Yq1dufhFlKG9rasfQlrY7wINJbo3q01tu56Jv5eBU5jirylhF2O5ZBnLxzOVBGRDz/9NAwNyBtG4Nyg==",
             "dev": true,
             "requires": {
                 "detect-newline": "^2.1.0"
             }
         },
         "jest-each": {
-            "version": "23.6.0",
-            "resolved":
-                "https://registry.npmjs.org/jest-each/-/jest-each-23.6.0.tgz",
-            "integrity":
-                "sha512-x7V6M/WGJo6/kLoissORuvLIeAoyo2YqLOoCDkohgJ4XOXSqOtyvr8FbInlAWS77ojBsZrafbozWoKVRdtxFCg==",
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.8.0.tgz",
+            "integrity": "sha512-NrwK9gaL5+XgrgoCsd9svsoWdVkK4gnvyhcpzd6m487tXHqIdYeykgq3MKI1u4I+5Zf0tofr70at9dWJDeb+BA==",
             "dev": true,
             "requires": {
+                "@jest/types": "^24.8.0",
                 "chalk": "^2.0.1",
-                "pretty-format": "^23.6.0"
+                "jest-get-type": "^24.8.0",
+                "jest-util": "^24.8.0",
+                "pretty-format": "^24.8.0"
             }
         },
         "jest-environment-jsdom": {
-            "version": "23.4.0",
-            "resolved":
-                "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.4.0.tgz",
-            "integrity": "sha1-BWp5UrP+pROsYqFAosNox52eYCM=",
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.8.0.tgz",
+            "integrity": "sha512-qbvgLmR7PpwjoFjM/sbuqHJt/NCkviuq9vus9NBn/76hhSidO+Z6Bn9tU8friecegbJL8gzZQEMZBQlFWDCwAQ==",
             "dev": true,
             "requires": {
-                "jest-mock": "^23.2.0",
-                "jest-util": "^23.4.0",
+                "@jest/environment": "^24.8.0",
+                "@jest/fake-timers": "^24.8.0",
+                "@jest/types": "^24.8.0",
+                "jest-mock": "^24.8.0",
+                "jest-util": "^24.8.0",
                 "jsdom": "^11.5.1"
             }
         },
         "jest-environment-node": {
-            "version": "23.4.0",
-            "resolved":
-                "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-23.4.0.tgz",
-            "integrity": "sha1-V+gO0IQd6jAxZ8zozXlSHeuv3hA=",
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.8.0.tgz",
+            "integrity": "sha512-vIGUEScd1cdDgR6sqn2M08sJTRLQp6Dk/eIkCeO4PFHxZMOgy+uYLPMC4ix3PEfM5Au/x3uQ/5Tl0DpXXZsJ/Q==",
             "dev": true,
             "requires": {
-                "jest-mock": "^23.2.0",
-                "jest-util": "^23.4.0"
+                "@jest/environment": "^24.8.0",
+                "@jest/fake-timers": "^24.8.0",
+                "@jest/types": "^24.8.0",
+                "jest-mock": "^24.8.0",
+                "jest-util": "^24.8.0"
             }
         },
         "jest-get-type": {
-            "version": "22.4.3",
-            "resolved":
-                "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
-            "integrity":
-                "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.8.0.tgz",
+            "integrity": "sha512-RR4fo8jEmMD9zSz2nLbs2j0zvPpk/KCEz3a62jJWbd2ayNo0cb+KFRxPHVhE4ZmgGJEQp0fosmNz84IfqM8cMQ==",
             "dev": true
         },
         "jest-haste-map": {
-            "version": "23.6.0",
-            "resolved":
-                "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.6.0.tgz",
-            "integrity":
-                "sha512-uyNhMyl6dr6HaXGHp8VF7cK6KpC6G9z9LiMNsst+rJIZ8l7wY0tk8qwjPmEghczojZ2/ZhtEdIabZ0OQRJSGGg==",
+            "version": "24.8.1",
+            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.8.1.tgz",
+            "integrity": "sha512-SwaxMGVdAZk3ernAx2Uv2sorA7jm3Kx+lR0grp6rMmnY06Kn/urtKx1LPN2mGTea4fCT38impYT28FfcLUhX0g==",
             "dev": true,
             "requires": {
+                "@jest/types": "^24.8.0",
+                "anymatch": "^2.0.0",
                 "fb-watchman": "^2.0.0",
-                "graceful-fs": "^4.1.11",
+                "fsevents": "^1.2.7",
+                "graceful-fs": "^4.1.15",
                 "invariant": "^2.2.4",
-                "jest-docblock": "^23.2.0",
-                "jest-serializer": "^23.0.1",
-                "jest-worker": "^23.2.0",
-                "micromatch": "^2.3.11",
-                "sane": "^2.0.0"
+                "jest-serializer": "^24.4.0",
+                "jest-util": "^24.8.0",
+                "jest-worker": "^24.6.0",
+                "micromatch": "^3.1.10",
+                "sane": "^4.0.3",
+                "walker": "^1.0.7"
             }
         },
         "jest-jasmine2": {
-            "version": "23.6.0",
-            "resolved":
-                "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.6.0.tgz",
-            "integrity":
-                "sha512-pe2Ytgs1nyCs8IvsEJRiRTPC0eVYd8L/dXJGU08GFuBwZ4sYH/lmFDdOL3ZmvJR8QKqV9MFuwlsAi/EWkFUbsQ==",
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.8.0.tgz",
+            "integrity": "sha512-cEky88npEE5LKd5jPpTdDCLvKkdyklnaRycBXL6GNmpxe41F0WN44+i7lpQKa/hcbXaQ+rc9RMaM4dsebrYong==",
             "dev": true,
             "requires": {
-                "babel-traverse": "^6.0.0",
+                "@babel/traverse": "^7.1.0",
+                "@jest/environment": "^24.8.0",
+                "@jest/test-result": "^24.8.0",
+                "@jest/types": "^24.8.0",
                 "chalk": "^2.0.1",
                 "co": "^4.6.0",
-                "expect": "^23.6.0",
-                "is-generator-fn": "^1.0.0",
-                "jest-diff": "^23.6.0",
-                "jest-each": "^23.6.0",
-                "jest-matcher-utils": "^23.6.0",
-                "jest-message-util": "^23.4.0",
-                "jest-snapshot": "^23.6.0",
-                "jest-util": "^23.4.0",
-                "pretty-format": "^23.6.0"
+                "expect": "^24.8.0",
+                "is-generator-fn": "^2.0.0",
+                "jest-each": "^24.8.0",
+                "jest-matcher-utils": "^24.8.0",
+                "jest-message-util": "^24.8.0",
+                "jest-runtime": "^24.8.0",
+                "jest-snapshot": "^24.8.0",
+                "jest-util": "^24.8.0",
+                "pretty-format": "^24.8.0",
+                "throat": "^4.0.0"
             }
         },
         "jest-leak-detector": {
-            "version": "23.6.0",
-            "resolved":
-                "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-23.6.0.tgz",
-            "integrity":
-                "sha512-f/8zA04rsl1Nzj10HIyEsXvYlMpMPcy0QkQilVZDFOaPbv2ur71X5u2+C4ZQJGyV/xvVXtCCZ3wQ99IgQxftCg==",
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.8.0.tgz",
+            "integrity": "sha512-cG0yRSK8A831LN8lIHxI3AblB40uhv0z+SsQdW3GoMMVcK+sJwrIIyax5tu3eHHNJ8Fu6IMDpnLda2jhn2pD/g==",
             "dev": true,
             "requires": {
-                "pretty-format": "^23.6.0"
+                "pretty-format": "^24.8.0"
             }
         },
         "jest-matcher-utils": {
-            "version": "23.6.0",
-            "resolved":
-                "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.6.0.tgz",
-            "integrity":
-                "sha512-rosyCHQfBcol4NsckTn01cdelzWLU9Cq7aaigDf8VwwpIRvWE/9zLgX2bON+FkEW69/0UuYslUe22SOdEf2nog==",
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.8.0.tgz",
+            "integrity": "sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==",
             "dev": true,
             "requires": {
                 "chalk": "^2.0.1",
-                "jest-get-type": "^22.1.0",
-                "pretty-format": "^23.6.0"
+                "jest-diff": "^24.8.0",
+                "jest-get-type": "^24.8.0",
+                "pretty-format": "^24.8.0"
             }
         },
         "jest-message-util": {
-            "version": "23.4.0",
-            "resolved":
-                "https://registry.npmjs.org/jest-message-util/-/jest-message-util-23.4.0.tgz",
-            "integrity": "sha1-F2EMUJQjSVCNAaPR4L2iwHkIap8=",
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.8.0.tgz",
+            "integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.0.0-beta.35",
+                "@babel/code-frame": "^7.0.0",
+                "@jest/test-result": "^24.8.0",
+                "@jest/types": "^24.8.0",
+                "@types/stack-utils": "^1.0.1",
                 "chalk": "^2.0.1",
-                "micromatch": "^2.3.11",
-                "slash": "^1.0.0",
+                "micromatch": "^3.1.10",
+                "slash": "^2.0.0",
                 "stack-utils": "^1.0.1"
             }
         },
         "jest-mock": {
-            "version": "23.2.0",
-            "resolved":
-                "https://registry.npmjs.org/jest-mock/-/jest-mock-23.2.0.tgz",
-            "integrity": "sha1-rRxg8p6HGdR8JuETgJi20YsmETQ=",
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.8.0.tgz",
+            "integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^24.8.0"
+            }
+        },
+        "jest-pnp-resolver": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
+            "integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
             "dev": true
         },
         "jest-regex-util": {
-            "version": "23.3.0",
-            "resolved":
-                "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.3.0.tgz",
-            "integrity": "sha1-X4ZylUfCeFxAAs6qj4Sf6MpHG8U=",
+            "version": "24.3.0",
+            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.3.0.tgz",
+            "integrity": "sha512-tXQR1NEOyGlfylyEjg1ImtScwMq8Oh3iJbGTjN7p0J23EuVX1MA8rwU69K4sLbCmwzgCUbVkm0FkSF9TdzOhtg==",
             "dev": true
         },
         "jest-resolve": {
-            "version": "23.6.0",
-            "resolved":
-                "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.6.0.tgz",
-            "integrity":
-                "sha512-XyoRxNtO7YGpQDmtQCmZjum1MljDqUCob7XlZ6jy9gsMugHdN2hY4+Acz9Qvjz2mSsOnPSH7skBmDYCHXVZqkA==",
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.8.0.tgz",
+            "integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
             "dev": true,
             "requires": {
+                "@jest/types": "^24.8.0",
                 "browser-resolve": "^1.11.3",
                 "chalk": "^2.0.1",
-                "realpath-native": "^1.0.0"
+                "jest-pnp-resolver": "^1.2.1",
+                "realpath-native": "^1.1.0"
             }
         },
         "jest-resolve-dependencies": {
-            "version": "23.6.0",
-            "resolved":
-                "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.6.0.tgz",
-            "integrity":
-                "sha512-EkQWkFWjGKwRtRyIwRwI6rtPAEyPWlUC2MpzHissYnzJeHcyCn1Hc8j7Nn1xUVrS5C6W5+ZL37XTem4D4pLZdA==",
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.8.0.tgz",
+            "integrity": "sha512-hyK1qfIf/krV+fSNyhyJeq3elVMhK9Eijlwy+j5jqmZ9QsxwKBiP6qukQxaHtK8k6zql/KYWwCTQ+fDGTIJauw==",
             "dev": true,
             "requires": {
-                "jest-regex-util": "^23.3.0",
-                "jest-snapshot": "^23.6.0"
+                "@jest/types": "^24.8.0",
+                "jest-regex-util": "^24.3.0",
+                "jest-snapshot": "^24.8.0"
             }
         },
         "jest-runner": {
-            "version": "23.6.0",
-            "resolved":
-                "https://registry.npmjs.org/jest-runner/-/jest-runner-23.6.0.tgz",
-            "integrity":
-                "sha512-kw0+uj710dzSJKU6ygri851CObtCD9cN8aNkg8jWJf4ewFyEa6kwmiH/r/M1Ec5IL/6VFa0wnAk6w+gzUtjJzA==",
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.8.0.tgz",
+            "integrity": "sha512-utFqC5BaA3JmznbissSs95X1ZF+d+4WuOWwpM9+Ak356YtMhHE/GXUondZdcyAAOTBEsRGAgH/0TwLzfI9h7ow==",
             "dev": true,
             "requires": {
+                "@jest/console": "^24.7.1",
+                "@jest/environment": "^24.8.0",
+                "@jest/test-result": "^24.8.0",
+                "@jest/types": "^24.8.0",
+                "chalk": "^2.4.2",
                 "exit": "^0.1.2",
-                "graceful-fs": "^4.1.11",
-                "jest-config": "^23.6.0",
-                "jest-docblock": "^23.2.0",
-                "jest-haste-map": "^23.6.0",
-                "jest-jasmine2": "^23.6.0",
-                "jest-leak-detector": "^23.6.0",
-                "jest-message-util": "^23.4.0",
-                "jest-runtime": "^23.6.0",
-                "jest-util": "^23.4.0",
-                "jest-worker": "^23.2.0",
+                "graceful-fs": "^4.1.15",
+                "jest-config": "^24.8.0",
+                "jest-docblock": "^24.3.0",
+                "jest-haste-map": "^24.8.0",
+                "jest-jasmine2": "^24.8.0",
+                "jest-leak-detector": "^24.8.0",
+                "jest-message-util": "^24.8.0",
+                "jest-resolve": "^24.8.0",
+                "jest-runtime": "^24.8.0",
+                "jest-util": "^24.8.0",
+                "jest-worker": "^24.6.0",
                 "source-map-support": "^0.5.6",
                 "throat": "^4.0.0"
             },
             "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved":
-                        "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity":
-                        "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                },
-                "source-map-support": {
-                    "version": "0.5.9",
-                    "resolved":
-                        "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-                    "integrity":
-                        "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "buffer-from": "^1.0.0",
-                        "source-map": "^0.6.0"
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
         },
         "jest-runtime": {
-            "version": "23.6.0",
-            "resolved":
-                "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.6.0.tgz",
-            "integrity":
-                "sha512-ycnLTNPT2Gv+TRhnAYAQ0B3SryEXhhRj1kA6hBPSeZaNQkJ7GbZsxOLUkwg6YmvWGdX3BB3PYKFLDQCAE1zNOw==",
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.8.0.tgz",
+            "integrity": "sha512-Mq0aIXhvO/3bX44ccT+czU1/57IgOMyy80oM0XR/nyD5zgBcesF84BPabZi39pJVA6UXw+fY2Q1N+4BiVUBWOA==",
             "dev": true,
             "requires": {
-                "babel-core": "^6.0.0",
-                "babel-plugin-istanbul": "^4.1.6",
+                "@jest/console": "^24.7.1",
+                "@jest/environment": "^24.8.0",
+                "@jest/source-map": "^24.3.0",
+                "@jest/transform": "^24.8.0",
+                "@jest/types": "^24.8.0",
+                "@types/yargs": "^12.0.2",
                 "chalk": "^2.0.1",
-                "convert-source-map": "^1.4.0",
                 "exit": "^0.1.2",
-                "fast-json-stable-stringify": "^2.0.0",
-                "graceful-fs": "^4.1.11",
-                "jest-config": "^23.6.0",
-                "jest-haste-map": "^23.6.0",
-                "jest-message-util": "^23.4.0",
-                "jest-regex-util": "^23.3.0",
-                "jest-resolve": "^23.6.0",
-                "jest-snapshot": "^23.6.0",
-                "jest-util": "^23.4.0",
-                "jest-validate": "^23.6.0",
-                "micromatch": "^2.3.11",
-                "realpath-native": "^1.0.0",
-                "slash": "^1.0.0",
-                "strip-bom": "3.0.0",
-                "write-file-atomic": "^2.1.0",
-                "yargs": "^11.0.0"
-            },
-            "dependencies": {
-                "strip-bom": {
-                    "version": "3.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-                    "dev": true
-                }
+                "glob": "^7.1.3",
+                "graceful-fs": "^4.1.15",
+                "jest-config": "^24.8.0",
+                "jest-haste-map": "^24.8.0",
+                "jest-message-util": "^24.8.0",
+                "jest-mock": "^24.8.0",
+                "jest-regex-util": "^24.3.0",
+                "jest-resolve": "^24.8.0",
+                "jest-snapshot": "^24.8.0",
+                "jest-util": "^24.8.0",
+                "jest-validate": "^24.8.0",
+                "realpath-native": "^1.1.0",
+                "slash": "^2.0.0",
+                "strip-bom": "^3.0.0",
+                "yargs": "^12.0.2"
             }
         },
         "jest-serializer": {
-            "version": "23.0.1",
-            "resolved":
-                "https://registry.npmjs.org/jest-serializer/-/jest-serializer-23.0.1.tgz",
-            "integrity": "sha1-o3dq6zEekP6D+rnlM+hRAr0WQWU=",
+            "version": "24.4.0",
+            "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.4.0.tgz",
+            "integrity": "sha512-k//0DtglVstc1fv+GY/VHDIjrtNjdYvYjMlbLUed4kxrE92sIUewOi5Hj3vrpB8CXfkJntRPDRjCrCvUhBdL8Q==",
             "dev": true
         },
         "jest-snapshot": {
-            "version": "23.6.0",
-            "resolved":
-                "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.6.0.tgz",
-            "integrity":
-                "sha512-tM7/Bprftun6Cvj2Awh/ikS7zV3pVwjRYU2qNYS51VZHgaAMBs5l4o/69AiDHhQrj5+LA2Lq4VIvK7zYk/bswg==",
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.8.0.tgz",
+            "integrity": "sha512-5ehtWoc8oU9/cAPe6fez6QofVJLBKyqkY2+TlKTOf0VllBB/mqUNdARdcjlZrs9F1Cv+/HKoCS/BknT0+tmfPg==",
             "dev": true,
             "requires": {
-                "babel-types": "^6.0.0",
+                "@babel/types": "^7.0.0",
+                "@jest/types": "^24.8.0",
                 "chalk": "^2.0.1",
-                "jest-diff": "^23.6.0",
-                "jest-matcher-utils": "^23.6.0",
-                "jest-message-util": "^23.4.0",
-                "jest-resolve": "^23.6.0",
+                "expect": "^24.8.0",
+                "jest-diff": "^24.8.0",
+                "jest-matcher-utils": "^24.8.0",
+                "jest-message-util": "^24.8.0",
+                "jest-resolve": "^24.8.0",
                 "mkdirp": "^0.5.1",
                 "natural-compare": "^1.4.0",
-                "pretty-format": "^23.6.0",
+                "pretty-format": "^24.8.0",
                 "semver": "^5.5.0"
             }
         },
         "jest-util": {
-            "version": "23.4.0",
-            "resolved":
-                "https://registry.npmjs.org/jest-util/-/jest-util-23.4.0.tgz",
-            "integrity": "sha1-TQY8uSe68KI4Mf9hvsLLv0l5NWE=",
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.8.0.tgz",
+            "integrity": "sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==",
             "dev": true,
             "requires": {
-                "callsites": "^2.0.0",
+                "@jest/console": "^24.7.1",
+                "@jest/fake-timers": "^24.8.0",
+                "@jest/source-map": "^24.3.0",
+                "@jest/test-result": "^24.8.0",
+                "@jest/types": "^24.8.0",
+                "callsites": "^3.0.0",
                 "chalk": "^2.0.1",
-                "graceful-fs": "^4.1.11",
-                "is-ci": "^1.0.10",
-                "jest-message-util": "^23.4.0",
+                "graceful-fs": "^4.1.15",
+                "is-ci": "^2.0.0",
                 "mkdirp": "^0.5.1",
-                "slash": "^1.0.0",
+                "slash": "^2.0.0",
                 "source-map": "^0.6.0"
             },
             "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved":
-                        "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity":
-                        "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                "ci-info": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+                    "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
                     "dev": true
+                },
+                "is-ci": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+                    "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+                    "dev": true,
+                    "requires": {
+                        "ci-info": "^2.0.0"
+                    }
                 }
             }
         },
         "jest-validate": {
-            "version": "23.6.0",
-            "resolved":
-                "https://registry.npmjs.org/jest-validate/-/jest-validate-23.6.0.tgz",
-            "integrity":
-                "sha512-OFKapYxe72yz7agrDAWi8v2WL8GIfVqcbKRCLbRG9PAxtzF9b1SEDdTpytNDN12z2fJynoBwpMpvj2R39plI2A==",
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.8.0.tgz",
+            "integrity": "sha512-+/N7VOEMW1Vzsrk3UWBDYTExTPwf68tavEPKDnJzrC6UlHtUDU/fuEdXqFoHzv9XnQ+zW6X3qMZhJ3YexfeLDA==",
             "dev": true,
             "requires": {
+                "@jest/types": "^24.8.0",
+                "camelcase": "^5.0.0",
                 "chalk": "^2.0.1",
-                "jest-get-type": "^22.1.0",
+                "jest-get-type": "^24.8.0",
                 "leven": "^2.1.0",
-                "pretty-format": "^23.6.0"
+                "pretty-format": "^24.8.0"
             }
         },
         "jest-watcher": {
-            "version": "23.4.0",
-            "resolved":
-                "https://registry.npmjs.org/jest-watcher/-/jest-watcher-23.4.0.tgz",
-            "integrity": "sha1-0uKM50+NrWxq/JIrksq+9u0FyRw=",
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.8.0.tgz",
+            "integrity": "sha512-SBjwHt5NedQoVu54M5GEx7cl7IGEFFznvd/HNT8ier7cCAx/Qgu9ZMlaTQkvK22G1YOpcWBLQPFSImmxdn3DAw==",
             "dev": true,
             "requires": {
+                "@jest/test-result": "^24.8.0",
+                "@jest/types": "^24.8.0",
+                "@types/yargs": "^12.0.9",
                 "ansi-escapes": "^3.0.0",
                 "chalk": "^2.0.1",
+                "jest-util": "^24.8.0",
                 "string-length": "^2.0.0"
             }
         },
         "jest-worker": {
-            "version": "23.2.0",
-            "resolved":
-                "https://registry.npmjs.org/jest-worker/-/jest-worker-23.2.0.tgz",
-            "integrity": "sha1-+vcGqNo2+uYOsmlXJX+ntdjqArk=",
+            "version": "24.6.0",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.6.0.tgz",
+            "integrity": "sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==",
             "dev": true,
             "requires": {
-                "merge-stream": "^1.0.1"
+                "merge-stream": "^1.0.1",
+                "supports-color": "^6.1.0"
+            },
+            "dependencies": {
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
             }
         },
         "js-tokens": {
-            "version": "3.0.2",
-            "resolved":
-                "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "dev": true
-        },
-        "js-yaml": {
-            "version": "3.12.0",
-            "resolved":
-                "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-            "integrity":
-                "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
-            "dev": true,
-            "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-            }
         },
         "jsbn": {
             "version": "0.1.1",
@@ -3681,8 +3341,7 @@
         "jsdom": {
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
-            "integrity":
-                "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
+            "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
             "dev": true,
             "requires": {
                 "abab": "^2.0.0",
@@ -3714,37 +3373,43 @@
             }
         },
         "jsesc": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-            "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+            "dev": true
+        },
+        "json-parse-better-errors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
             "dev": true
         },
         "json-schema": {
             "version": "0.2.3",
-            "resolved":
-                "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
             "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
             "dev": true
         },
         "json-schema-traverse": {
-            "version": "0.3.1",
-            "resolved":
-                "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
         },
         "json-stringify-safe": {
             "version": "5.0.1",
-            "resolved":
-                "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
             "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
             "dev": true
         },
         "json5": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-            "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-            "dev": true
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+            "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+            "dev": true,
+            "requires": {
+                "minimist": "^1.2.0"
+            }
         },
         "jsprim": {
             "version": "1.4.1",
@@ -3759,37 +3424,30 @@
             }
         },
         "kind-of": {
-            "version": "3.2.2",
-            "resolved":
-                "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-            "dev": true,
-            "requires": {
-                "is-buffer": "^1.1.5"
-            }
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+            "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+            "dev": true
         },
         "kleur": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/kleur/-/kleur-2.0.2.tgz",
-            "integrity":
-                "sha512-77XF9iTllATmG9lSlIv0qdQ2BQ/h9t0bJllHlbvsQ0zUWfU7Yi0S8L5JXzPZgkefIiajLmBJJ4BsMJmqcf7oxQ==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+            "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
             "dev": true
         },
         "lcid": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+            "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
             "dev": true,
             "requires": {
-                "invert-kv": "^1.0.0"
+                "invert-kv": "^2.0.0"
             }
         },
         "left-pad": {
             "version": "1.3.0",
-            "resolved":
-                "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-            "integrity":
-                "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+            "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+            "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
             "dev": true
         },
         "leven": {
@@ -3809,23 +3467,20 @@
             }
         },
         "load-json-file": {
-            "version": "1.1.0",
-            "resolved":
-                "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-            "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+            "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
-                "parse-json": "^2.2.0",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0",
-                "strip-bom": "^2.0.0"
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
             }
         },
         "locate-path": {
             "version": "2.0.0",
-            "resolved":
-                "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
             "dev": true,
             "requires": {
@@ -3835,25 +3490,20 @@
         },
         "lodash": {
             "version": "4.17.11",
-            "resolved":
-                "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-            "integrity":
-                "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
             "dev": true
         },
         "lodash.sortby": {
             "version": "4.7.0",
-            "resolved":
-                "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+            "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
             "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
             "dev": true
         },
         "loose-envify": {
             "version": "1.4.0",
-            "resolved":
-                "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-            "integrity":
-                "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
             "dev": true,
             "requires": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
@@ -3861,70 +3511,79 @@
         },
         "lru-cache": {
             "version": "4.1.1",
-            "resolved":
-                "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-            "integrity":
-                "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+            "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
             "dev": true,
             "requires": {
                 "pseudomap": "^1.0.2",
                 "yallist": "^2.1.2"
             }
         },
+        "make-dir": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+            "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+            "dev": true,
+            "requires": {
+                "pify": "^4.0.1",
+                "semver": "^5.6.0"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+                    "dev": true
+                }
+            }
+        },
         "makeerror": {
             "version": "1.0.11",
-            "resolved":
-                "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+            "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
             "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
             "dev": true,
             "requires": {
                 "tmpl": "1.0.x"
             }
         },
+        "map-age-cleaner": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+            "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+            "dev": true,
+            "requires": {
+                "p-defer": "^1.0.0"
+            }
+        },
         "map-cache": {
             "version": "0.2.2",
-            "resolved":
-                "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+            "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
             "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
             "dev": true
         },
         "map-visit": {
             "version": "1.0.0",
-            "resolved":
-                "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
             "dev": true,
             "requires": {
                 "object-visit": "^1.0.0"
             }
         },
-        "math-random": {
-            "version": "1.0.1",
-            "resolved":
-                "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-            "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
-            "dev": true
-        },
         "mem": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-            "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+            "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
             "dev": true,
             "requires": {
-                "mimic-fn": "^1.0.0"
+                "map-age-cleaner": "^0.1.1",
+                "mimic-fn": "^2.0.0",
+                "p-is-promise": "^2.0.0"
             }
-        },
-        "merge": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
-            "integrity":
-                "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
-            "dev": true
         },
         "merge-stream": {
             "version": "1.0.1",
-            "resolved":
-                "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
             "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
             "dev": true,
             "requires": {
@@ -3932,78 +3591,66 @@
             }
         },
         "micromatch": {
-            "version": "2.3.11",
-            "resolved":
-                "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-            "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+            "version": "3.1.10",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+            "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
             "dev": true,
             "requires": {
-                "arr-diff": "^2.0.0",
-                "array-unique": "^0.2.1",
-                "braces": "^1.8.2",
-                "expand-brackets": "^0.1.4",
-                "extglob": "^0.3.1",
-                "filename-regex": "^2.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.1",
-                "kind-of": "^3.0.2",
-                "normalize-path": "^2.0.1",
-                "object.omit": "^2.0.0",
-                "parse-glob": "^3.0.4",
-                "regex-cache": "^0.4.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
             }
         },
         "mime-db": {
-            "version": "1.37.0",
-            "resolved":
-                "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-            "integrity":
-                "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
+            "version": "1.40.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+            "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
             "dev": true
         },
         "mime-types": {
-            "version": "2.1.21",
-            "resolved":
-                "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-            "integrity":
-                "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+            "version": "2.1.24",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+            "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
             "dev": true,
             "requires": {
-                "mime-db": "~1.37.0"
+                "mime-db": "1.40.0"
             }
         },
         "mimic-fn": {
-            "version": "1.2.0",
-            "resolved":
-                "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-            "integrity":
-                "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
             "dev": true
         },
         "minimatch": {
             "version": "3.0.4",
-            "resolved":
-                "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity":
-                "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
-            "version": "0.0.8",
-            "resolved":
-                "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
             "dev": true
         },
         "mixin-deep": {
-            "version": "1.3.1",
-            "resolved":
-                "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-            "integrity":
-                "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+            "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
             "dev": true,
             "requires": {
                 "for-in": "^1.0.2",
@@ -4012,10 +3659,8 @@
             "dependencies": {
                 "is-extendable": {
                     "version": "1.0.1",
-                    "resolved":
-                        "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-                    "integrity":
-                        "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
                         "is-plain-object": "^2.0.4"
@@ -4030,12 +3675,20 @@
             "dev": true,
             "requires": {
                 "minimist": "0.0.8"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "0.0.8",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                    "dev": true
+                }
             }
         },
         "mri": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.0.tgz",
-            "integrity": "sha1-XAo/KcjM/7ux7JQdzsCdcfoy82o=",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
+            "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==",
             "dev": true
         },
         "ms": {
@@ -4043,20 +3696,29 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
+        "multimatch": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-3.0.0.tgz",
+            "integrity": "sha512-22foS/gqQfANZ3o+W7ST2x25ueHDVNWl/b9OlGcLpy/iKxjCpvcNCM51YCenUi7Mt/jAjjqv8JwZRs8YP5sRjA==",
+            "dev": true,
+            "requires": {
+                "array-differ": "^2.0.3",
+                "array-union": "^1.0.2",
+                "arrify": "^1.0.1",
+                "minimatch": "^3.0.4"
+            }
+        },
         "nan": {
-            "version": "2.11.1",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-            "integrity":
-                "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+            "version": "2.14.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+            "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
             "dev": true,
             "optional": true
         },
         "nanomatch": {
             "version": "1.2.13",
-            "resolved":
-                "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
-            "integrity":
-                "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+            "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+            "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
             "dev": true,
             "requires": {
                 "arr-diff": "^4.0.0",
@@ -4070,78 +3732,66 @@
                 "regex-not": "^1.0.0",
                 "snapdragon": "^0.8.1",
                 "to-regex": "^3.0.1"
-            },
-            "dependencies": {
-                "arr-diff": {
-                    "version": "4.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-                    "dev": true
-                },
-                "array-unique": {
-                    "version": "0.3.2",
-                    "resolved":
-                        "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-                    "dev": true
-                },
-                "kind-of": {
-                    "version": "6.0.2",
-                    "resolved":
-                        "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity":
-                        "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-                    "dev": true
-                }
             }
         },
         "natural-compare": {
             "version": "1.4.0",
-            "resolved":
-                "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "dev": true
+        },
+        "neo-async": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+            "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+            "dev": true
+        },
+        "nice-try": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+            "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
             "dev": true
         },
         "node-int64": {
             "version": "0.4.0",
-            "resolved":
-                "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+            "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
             "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
             "dev": true
         },
+        "node-modules-regexp": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+            "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+            "dev": true
+        },
         "node-notifier": {
-            "version": "5.3.0",
-            "resolved":
-                "https://registry.npmjs.org/node-notifier/-/node-notifier-5.3.0.tgz",
-            "integrity":
-                "sha512-AhENzCSGZnZJgBARsUjnQ7DnZbzyP+HxlVXuD0xqAnvL8q+OqtSX7lGg9e8nHzwXkMMXNdVeqq4E2M3EUAqX6Q==",
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
+            "integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
             "dev": true,
             "requires": {
                 "growly": "^1.3.0",
+                "is-wsl": "^1.1.0",
                 "semver": "^5.5.0",
                 "shellwords": "^0.1.1",
                 "which": "^1.3.0"
             }
         },
         "normalize-package-data": {
-            "version": "2.4.0",
-            "resolved":
-                "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-            "integrity":
-                "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
             "dev": true,
             "requires": {
                 "hosted-git-info": "^2.1.4",
-                "is-builtin-module": "^1.0.0",
+                "resolve": "^1.10.0",
                 "semver": "2 || 3 || 4 || 5",
                 "validate-npm-package-license": "^3.0.1"
             }
         },
         "normalize-path": {
             "version": "2.1.1",
-            "resolved":
-                "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
@@ -4150,8 +3800,7 @@
         },
         "npm-run-path": {
             "version": "2.0.2",
-            "resolved":
-                "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
             "dev": true,
             "requires": {
@@ -4160,43 +3809,30 @@
         },
         "number-is-nan": {
             "version": "1.0.1",
-            "resolved":
-                "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
             "dev": true
         },
         "nwsapi": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.9.tgz",
-            "integrity":
-                "sha512-nlWFSCTYQcHk/6A9FFnfhKc14c3aFhfdNBXgo8Qgi9QTBu/qg3Ww+Uiz9wMzXd1T8GFxPc2QIHB6Qtf2XFryFQ==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.4.tgz",
+            "integrity": "sha512-iGfd9Y6SFdTNldEy2L0GUhcarIutFmk+MPWIn9dmj8NMIup03G08uUF2KGbbmv/Ux4RT0VZJoP/sVbWA6d/VIw==",
             "dev": true
         },
         "oauth-sign": {
             "version": "0.9.0",
-            "resolved":
-                "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-            "integrity":
-                "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-            "dev": true
-        },
-        "object-assign": {
-            "version": "4.1.1",
-            "resolved":
-                "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
             "dev": true
         },
         "object-assign-deep": {
             "version": "0.3.1",
-            "resolved":
-                "https://registry.npmjs.org/object-assign-deep/-/object-assign-deep-0.3.1.tgz",
+            "resolved": "https://registry.npmjs.org/object-assign-deep/-/object-assign-deep-0.3.1.tgz",
             "integrity": "sha1-tXt1ctmjKNZEij9LbA//yLEMYaI="
         },
         "object-copy": {
             "version": "0.1.0",
-            "resolved":
-                "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
             "dev": true,
             "requires": {
@@ -4207,47 +3843,42 @@
             "dependencies": {
                 "define-property": {
                     "version": "0.2.5",
-                    "resolved":
-                        "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
                 }
             }
         },
         "object-keys": {
-            "version": "1.0.12",
-            "resolved":
-                "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-            "integrity":
-                "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
             "dev": true
         },
         "object-visit": {
             "version": "1.0.1",
-            "resolved":
-                "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
             "dev": true,
             "requires": {
                 "isobject": "^3.0.0"
-            },
-            "dependencies": {
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved":
-                        "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
-                }
             }
         },
         "object.getownpropertydescriptors": {
             "version": "2.0.3",
-            "resolved":
-                "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
             "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
             "dev": true,
             "requires": {
@@ -4255,34 +3886,13 @@
                 "es-abstract": "^1.5.1"
             }
         },
-        "object.omit": {
-            "version": "2.0.1",
-            "resolved":
-                "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-            "dev": true,
-            "requires": {
-                "for-own": "^0.1.4",
-                "is-extendable": "^0.1.1"
-            }
-        },
         "object.pick": {
             "version": "1.3.0",
-            "resolved":
-                "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "dev": true,
             "requires": {
                 "isobject": "^3.0.1"
-            },
-            "dependencies": {
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved":
-                        "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
-                }
             }
         },
         "once": {
@@ -4296,19 +3906,25 @@
         },
         "optimist": {
             "version": "0.6.1",
-            "resolved":
-                "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
             "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
             "dev": true,
             "requires": {
                 "minimist": "~0.0.1",
                 "wordwrap": "~0.0.2"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "0.0.10",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                    "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+                    "dev": true
+                }
             }
         },
         "optionator": {
             "version": "0.8.2",
-            "resolved":
-                "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
             "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
             "dev": true,
             "requires": {
@@ -4322,53 +3938,54 @@
             "dependencies": {
                 "wordwrap": {
                     "version": "1.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
                     "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
                     "dev": true
                 }
             }
         },
-        "os-homedir": {
-            "version": "1.0.2",
-            "resolved":
-                "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-            "dev": true
-        },
         "os-locale": {
-            "version": "2.1.0",
-            "resolved":
-                "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-            "integrity":
-                "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+            "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
             "dev": true,
             "requires": {
-                "execa": "^0.7.0",
-                "lcid": "^1.0.0",
-                "mem": "^1.1.0"
+                "execa": "^1.0.0",
+                "lcid": "^2.0.0",
+                "mem": "^4.0.0"
             }
         },
-        "os-tmpdir": {
-            "version": "1.0.2",
-            "resolved":
-                "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+        "p-defer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+            "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
             "dev": true
+        },
+        "p-each-series": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
+            "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
+            "dev": true,
+            "requires": {
+                "p-reduce": "^1.0.0"
+            }
         },
         "p-finally": {
             "version": "1.0.0",
-            "resolved":
-                "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
             "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+            "dev": true
+        },
+        "p-is-promise": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+            "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
             "dev": true
         },
         "p-limit": {
             "version": "1.2.0",
-            "resolved":
-                "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
-            "integrity":
-                "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+            "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
             "dev": true,
             "requires": {
                 "p-try": "^1.0.0"
@@ -4376,13 +3993,18 @@
         },
         "p-locate": {
             "version": "2.0.0",
-            "resolved":
-                "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
             "dev": true,
             "requires": {
                 "p-limit": "^1.1.0"
             }
+        },
+        "p-reduce": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
+            "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
+            "dev": true
         },
         "p-try": {
             "version": "1.0.0",
@@ -4390,198 +4012,189 @@
             "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
             "dev": true
         },
-        "parse-glob": {
-            "version": "3.0.4",
-            "resolved":
-                "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-            "dev": true,
-            "requires": {
-                "glob-base": "^0.3.0",
-                "is-dotfile": "^1.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.0"
-            }
-        },
         "parse-json": {
-            "version": "2.2.0",
-            "resolved":
-                "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-            "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+            "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
             "dev": true,
             "requires": {
-                "error-ex": "^1.2.0"
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
             }
         },
         "parse5": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-            "integrity":
-                "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+            "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
             "dev": true
         },
         "pascalcase": {
             "version": "0.1.1",
-            "resolved":
-                "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
             "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
             "dev": true
         },
         "path-exists": {
             "version": "3.0.0",
-            "resolved":
-                "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
             "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
             "dev": true
         },
         "path-is-absolute": {
             "version": "1.0.1",
-            "resolved":
-                "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
             "dev": true
         },
         "path-key": {
             "version": "2.0.1",
-            "resolved":
-                "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
             "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
             "dev": true
         },
         "path-parse": {
             "version": "1.0.6",
-            "resolved":
-                "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-            "integrity":
-                "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
             "dev": true
         },
         "path-type": {
-            "version": "1.1.0",
-            "resolved":
-                "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-            "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+            "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
+                "pify": "^3.0.0"
             }
         },
         "performance-now": {
             "version": "2.1.0",
-            "resolved":
-                "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
             "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
             "dev": true
         },
         "pify": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
             "dev": true
         },
-        "pinkie": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-            "dev": true
-        },
-        "pinkie-promise": {
-            "version": "2.0.1",
-            "resolved":
-                "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+        "pirates": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
+            "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
             "dev": true,
             "requires": {
-                "pinkie": "^2.0.0"
+                "node-modules-regexp": "^1.0.0"
             }
         },
         "pkg-dir": {
-            "version": "2.0.0",
-            "resolved":
-                "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-            "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+            "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
             "dev": true,
             "requires": {
-                "find-up": "^2.1.0"
+                "find-up": "^3.0.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+                    "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "dev": true
+                }
             }
         },
         "pn": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-            "integrity":
-                "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+            "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
             "dev": true
         },
         "posix-character-classes": {
             "version": "0.1.1",
-            "resolved":
-                "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
             "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
             "dev": true
         },
         "prelude-ls": {
             "version": "1.1.2",
-            "resolved":
-                "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
             "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
             "dev": true
         },
-        "preserve": {
-            "version": "0.2.0",
-            "resolved":
-                "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-            "dev": true
-        },
         "prettier": {
-            "version": "1.12.1",
-            "resolved":
-                "https://registry.npmjs.org/prettier/-/prettier-1.12.1.tgz",
-            "integrity": "sha1-wa0g6APndJ+vkFpAnSNn4Gu+cyU=",
+            "version": "1.18.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+            "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
             "dev": true
         },
         "pretty-format": {
-            "version": "23.6.0",
-            "resolved":
-                "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
-            "integrity":
-                "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
+            "version": "24.8.0",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.8.0.tgz",
+            "integrity": "sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==",
             "dev": true,
             "requires": {
-                "ansi-regex": "^3.0.0",
-                "ansi-styles": "^3.2.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                    "dev": true
-                }
+                "@jest/types": "^24.8.0",
+                "ansi-regex": "^4.0.0",
+                "ansi-styles": "^3.2.0",
+                "react-is": "^16.8.4"
             }
         },
         "pretty-quick": {
-            "version": "1.4.1",
-            "resolved":
-                "https://registry.npmjs.org/pretty-quick/-/pretty-quick-1.4.1.tgz",
-            "integrity":
-                "sha512-Q4V2GAflSaM739kKH63utbfI2n4s2fCDCyjFC4ykxA9ueb7FknLcLAZSKa3DejHMt5q9Fq395eKTZ9wYwoILBw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-1.11.1.tgz",
+            "integrity": "sha512-kSXCkcETfak7EQXz6WOkCeCqpbC4GIzrN/vaneTGMP/fAtD8NerA9bPhCUqHAks1geo7biZNl5uEMPceeneLuA==",
             "dev": true,
             "requires": {
                 "chalk": "^2.3.0",
                 "execa": "^0.8.0",
                 "find-up": "^2.1.0",
                 "ignore": "^3.3.7",
-                "mri": "^1.1.0"
+                "mri": "^1.1.0",
+                "multimatch": "^3.0.0"
             },
             "dependencies": {
                 "execa": {
                     "version": "0.8.0",
-                    "resolved":
-                        "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
                     "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
                     "dev": true,
                     "requires": {
@@ -4596,146 +4209,132 @@
                 }
             }
         },
-        "private": {
-            "version": "0.1.8",
-            "resolved":
-                "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-            "integrity":
-                "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
-            "dev": true
-        },
         "process-nextick-args": {
-            "version": "2.0.0",
-            "resolved":
-                "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-            "integrity":
-                "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "dev": true
         },
         "prompts": {
-            "version": "0.1.14",
-            "resolved":
-                "https://registry.npmjs.org/prompts/-/prompts-0.1.14.tgz",
-            "integrity":
-                "sha512-rxkyiE9YH6zAz/rZpywySLKkpaj0NMVyNw1qhsubdbjjSgcayjTShDreZGlFMcGSu5sab3bAKPfFk78PB90+8w==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.1.0.tgz",
+            "integrity": "sha512-+x5TozgqYdOwWsQFZizE/Tra3fKvAoy037kOyU6cgz84n8f6zxngLOV4O32kTwt9FcLCxAqw0P/c8rOr9y+Gfg==",
             "dev": true,
             "requires": {
-                "kleur": "^2.0.1",
-                "sisteransi": "^0.1.1"
+                "kleur": "^3.0.2",
+                "sisteransi": "^1.0.0"
             }
         },
         "pseudomap": {
             "version": "1.0.2",
-            "resolved":
-                "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
             "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
             "dev": true
         },
         "psl": {
-            "version": "1.1.29",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-            "integrity":
-                "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.2.0.tgz",
+            "integrity": "sha512-GEn74ZffufCmkDDLNcl3uuyF/aSD6exEyh1v/ZSdAomB82t6G9hzJVRx0jBmLDW+VfZqks3aScmMw9DszwUalA==",
             "dev": true
+        },
+        "pump": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
         },
         "punycode": {
             "version": "2.1.1",
-            "resolved":
-                "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-            "integrity":
-                "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
             "dev": true
         },
         "qs": {
             "version": "6.5.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-            "integrity":
-                "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
             "dev": true
         },
-        "randomatic": {
-            "version": "3.1.1",
-            "resolved":
-                "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
-            "integrity":
-                "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
-            "dev": true,
-            "requires": {
-                "is-number": "^4.0.0",
-                "kind-of": "^6.0.0",
-                "math-random": "^1.0.1"
-            },
-            "dependencies": {
-                "is-number": {
-                    "version": "4.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-                    "integrity":
-                        "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-                    "dev": true
-                },
-                "kind-of": {
-                    "version": "6.0.2",
-                    "resolved":
-                        "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity":
-                        "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-                    "dev": true
-                }
-            }
+        "react-is": {
+            "version": "16.8.6",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+            "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
+            "dev": true
         },
         "read-pkg": {
-            "version": "1.1.0",
-            "resolved":
-                "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-            "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+            "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
             "dev": true,
             "requires": {
-                "load-json-file": "^1.0.0",
+                "load-json-file": "^4.0.0",
                 "normalize-package-data": "^2.3.2",
-                "path-type": "^1.0.0"
+                "path-type": "^3.0.0"
             }
         },
         "read-pkg-up": {
-            "version": "1.0.1",
-            "resolved":
-                "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-            "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+            "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
             "dev": true,
             "requires": {
-                "find-up": "^1.0.0",
-                "read-pkg": "^1.0.0"
+                "find-up": "^3.0.0",
+                "read-pkg": "^3.0.0"
             },
             "dependencies": {
                 "find-up": {
-                    "version": "1.1.2",
-                    "resolved":
-                        "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                    "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
                     "dev": true,
                     "requires": {
-                        "path-exists": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
+                        "locate-path": "^3.0.0"
                     }
                 },
-                "path-exists": {
-                    "version": "2.1.0",
-                    "resolved":
-                        "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-                    "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
                     "dev": true,
                     "requires": {
-                        "pinkie-promise": "^2.0.0"
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
                     }
+                },
+                "p-limit": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+                    "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "dev": true
                 }
             }
         },
         "readable-stream": {
             "version": "2.3.6",
-            "resolved":
-                "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-            "integrity":
-                "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+            "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "dev": true,
             "requires": {
                 "core-util-is": "~1.0.0",
@@ -4748,41 +4347,18 @@
             }
         },
         "realpath-native": {
-            "version": "1.0.2",
-            "resolved":
-                "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.2.tgz",
-            "integrity":
-                "sha512-+S3zTvVt9yTntFrBpm7TQmQ3tzpCrnA1a/y+3cUHAc9ZR6aIjG0WNLR+Rj79QpJktY+VeW/TQtFlQ1bzsehI8g==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
+            "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
             "dev": true,
             "requires": {
                 "util.promisify": "^1.0.0"
             }
         },
-        "regenerator-runtime": {
-            "version": "0.11.1",
-            "resolved":
-                "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-            "integrity":
-                "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-            "dev": true
-        },
-        "regex-cache": {
-            "version": "0.4.4",
-            "resolved":
-                "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-            "integrity":
-                "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-            "dev": true,
-            "requires": {
-                "is-equal-shallow": "^0.1.3"
-            }
-        },
         "regex-not": {
             "version": "1.0.2",
-            "resolved":
-                "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-            "integrity":
-                "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+            "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+            "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
             "dev": true,
             "requires": {
                 "extend-shallow": "^3.0.2",
@@ -4791,42 +4367,26 @@
         },
         "remove-trailing-separator": {
             "version": "1.1.0",
-            "resolved":
-                "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
             "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
             "dev": true
         },
         "repeat-element": {
             "version": "1.1.3",
-            "resolved":
-                "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-            "integrity":
-                "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+            "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+            "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
             "dev": true
         },
         "repeat-string": {
             "version": "1.6.1",
-            "resolved":
-                "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
             "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
             "dev": true
         },
-        "repeating": {
-            "version": "2.0.1",
-            "resolved":
-                "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-            "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-            "dev": true,
-            "requires": {
-                "is-finite": "^1.0.0"
-            }
-        },
         "request": {
             "version": "2.88.0",
-            "resolved":
-                "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-            "integrity":
-                "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+            "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
             "dev": true,
             "requires": {
                 "aws-sign2": "~0.7.0",
@@ -4849,55 +4409,70 @@
                 "tough-cookie": "~2.4.3",
                 "tunnel-agent": "^0.6.0",
                 "uuid": "^3.3.2"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+                    "dev": true
+                },
+                "tough-cookie": {
+                    "version": "2.4.3",
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+                    "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+                    "dev": true,
+                    "requires": {
+                        "psl": "^1.1.24",
+                        "punycode": "^1.4.1"
+                    }
+                }
             }
         },
         "request-promise-core": {
-            "version": "1.1.1",
-            "resolved":
-                "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-            "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+            "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
             "dev": true,
             "requires": {
-                "lodash": "^4.13.1"
+                "lodash": "^4.17.11"
             }
         },
         "request-promise-native": {
-            "version": "1.0.5",
-            "resolved":
-                "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
-            "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
+            "integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
             "dev": true,
             "requires": {
-                "request-promise-core": "1.1.1",
-                "stealthy-require": "^1.1.0",
-                "tough-cookie": ">=2.3.3"
+                "request-promise-core": "1.1.2",
+                "stealthy-require": "^1.1.1",
+                "tough-cookie": "^2.3.3"
             }
         },
         "require-directory": {
             "version": "2.1.1",
-            "resolved":
-                "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
             "dev": true
         },
         "require-main-filename": {
-            "version": "1.0.1",
-            "resolved":
-                "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+            "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
             "dev": true
         },
         "resolve": {
-            "version": "1.1.7",
-            "resolved":
-                "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-            "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-            "dev": true
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+            "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+            "dev": true,
+            "requires": {
+                "path-parse": "^1.0.6"
+            }
         },
         "resolve-cwd": {
             "version": "2.0.0",
-            "resolved":
-                "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
             "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
             "dev": true,
             "requires": {
@@ -4906,54 +4481,46 @@
         },
         "resolve-from": {
             "version": "3.0.0",
-            "resolved":
-                "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
             "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
             "dev": true
         },
         "resolve-url": {
             "version": "0.2.1",
-            "resolved":
-                "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+            "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
             "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
             "dev": true
         },
         "ret": {
             "version": "0.1.15",
             "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-            "integrity":
-                "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
             "dev": true
         },
         "rimraf": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-            "integrity":
-                "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+            "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
             "dev": true,
             "requires": {
-                "glob": "^7.0.5"
+                "glob": "^7.1.3"
             }
         },
         "rsvp": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-            "integrity":
-                "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+            "version": "4.8.5",
+            "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+            "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
             "dev": true
         },
         "safe-buffer": {
             "version": "5.1.2",
-            "resolved":
-                "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity":
-                "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
             "dev": true
         },
         "safe-regex": {
             "version": "1.1.0",
-            "resolved":
-                "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
@@ -4962,376 +4529,49 @@
         },
         "safer-buffer": {
             "version": "2.1.2",
-            "resolved":
-                "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity":
-                "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "dev": true
         },
         "sane": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
-            "integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
+            "integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
             "dev": true,
             "requires": {
+                "@cnakazawa/watch": "^1.0.3",
                 "anymatch": "^2.0.0",
-                "capture-exit": "^1.2.0",
-                "exec-sh": "^0.2.0",
+                "capture-exit": "^2.0.0",
+                "exec-sh": "^0.3.2",
+                "execa": "^1.0.0",
                 "fb-watchman": "^2.0.0",
-                "fsevents": "^1.2.3",
                 "micromatch": "^3.1.4",
                 "minimist": "^1.1.1",
-                "walker": "~1.0.5",
-                "watch": "~0.18.0"
-            },
-            "dependencies": {
-                "arr-diff": {
-                    "version": "4.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-                    "dev": true
-                },
-                "array-unique": {
-                    "version": "0.3.2",
-                    "resolved":
-                        "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-                    "dev": true
-                },
-                "braces": {
-                    "version": "2.3.2",
-                    "resolved":
-                        "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-                    "integrity":
-                        "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-                    "dev": true,
-                    "requires": {
-                        "arr-flatten": "^1.1.0",
-                        "array-unique": "^0.3.2",
-                        "extend-shallow": "^2.0.1",
-                        "fill-range": "^4.0.0",
-                        "isobject": "^3.0.1",
-                        "repeat-element": "^1.1.2",
-                        "snapdragon": "^0.8.1",
-                        "snapdragon-node": "^2.0.1",
-                        "split-string": "^3.0.2",
-                        "to-regex": "^3.0.1"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved":
-                                "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "dev": true,
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "expand-brackets": {
-                    "version": "2.1.4",
-                    "resolved":
-                        "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-                    "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-                    "dev": true,
-                    "requires": {
-                        "debug": "^2.3.3",
-                        "define-property": "^0.2.5",
-                        "extend-shallow": "^2.0.1",
-                        "posix-character-classes": "^0.1.0",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.1"
-                    },
-                    "dependencies": {
-                        "define-property": {
-                            "version": "0.2.5",
-                            "resolved":
-                                "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-                            "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                            "dev": true,
-                            "requires": {
-                                "is-descriptor": "^0.1.0"
-                            }
-                        },
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved":
-                                "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "dev": true,
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        },
-                        "is-accessor-descriptor": {
-                            "version": "0.1.6",
-                            "resolved":
-                                "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-                            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-                            "dev": true,
-                            "requires": {
-                                "kind-of": "^3.0.2"
-                            },
-                            "dependencies": {
-                                "kind-of": {
-                                    "version": "3.2.2",
-                                    "resolved":
-                                        "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                                    "integrity":
-                                        "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                                    "dev": true,
-                                    "requires": {
-                                        "is-buffer": "^1.1.5"
-                                    }
-                                }
-                            }
-                        },
-                        "is-data-descriptor": {
-                            "version": "0.1.4",
-                            "resolved":
-                                "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-                            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-                            "dev": true,
-                            "requires": {
-                                "kind-of": "^3.0.2"
-                            },
-                            "dependencies": {
-                                "kind-of": {
-                                    "version": "3.2.2",
-                                    "resolved":
-                                        "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                                    "integrity":
-                                        "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                                    "dev": true,
-                                    "requires": {
-                                        "is-buffer": "^1.1.5"
-                                    }
-                                }
-                            }
-                        },
-                        "is-descriptor": {
-                            "version": "0.1.6",
-                            "resolved":
-                                "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-                            "integrity":
-                                "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-                            "dev": true,
-                            "requires": {
-                                "is-accessor-descriptor": "^0.1.6",
-                                "is-data-descriptor": "^0.1.4",
-                                "kind-of": "^5.0.0"
-                            }
-                        },
-                        "kind-of": {
-                            "version": "5.1.0",
-                            "resolved":
-                                "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                            "integrity":
-                                "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-                            "dev": true
-                        }
-                    }
-                },
-                "extglob": {
-                    "version": "2.0.4",
-                    "resolved":
-                        "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-                    "integrity":
-                        "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-                    "dev": true,
-                    "requires": {
-                        "array-unique": "^0.3.2",
-                        "define-property": "^1.0.0",
-                        "expand-brackets": "^2.1.4",
-                        "extend-shallow": "^2.0.1",
-                        "fragment-cache": "^0.2.1",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.1"
-                    },
-                    "dependencies": {
-                        "define-property": {
-                            "version": "1.0.0",
-                            "resolved":
-                                "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-                            "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-                            "dev": true,
-                            "requires": {
-                                "is-descriptor": "^1.0.0"
-                            }
-                        },
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved":
-                                "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "dev": true,
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "fill-range": {
-                    "version": "4.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-                    "dev": true,
-                    "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1",
-                        "to-regex-range": "^2.1.0"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved":
-                                "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "dev": true,
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "is-accessor-descriptor": {
-                    "version": "1.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-                    "integrity":
-                        "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^6.0.0"
-                    }
-                },
-                "is-data-descriptor": {
-                    "version": "1.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-                    "integrity":
-                        "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^6.0.0"
-                    }
-                },
-                "is-descriptor": {
-                    "version": "1.0.2",
-                    "resolved":
-                        "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-                    "integrity":
-                        "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-                    "dev": true,
-                    "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
-                    }
-                },
-                "is-number": {
-                    "version": "3.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved":
-                                "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "dev": true,
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
-                    }
-                },
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved":
-                        "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
-                },
-                "kind-of": {
-                    "version": "6.0.2",
-                    "resolved":
-                        "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity":
-                        "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-                    "dev": true
-                },
-                "micromatch": {
-                    "version": "3.1.10",
-                    "resolved":
-                        "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-                    "integrity":
-                        "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-                    "dev": true,
-                    "requires": {
-                        "arr-diff": "^4.0.0",
-                        "array-unique": "^0.3.2",
-                        "braces": "^2.3.1",
-                        "define-property": "^2.0.2",
-                        "extend-shallow": "^3.0.2",
-                        "extglob": "^2.0.4",
-                        "fragment-cache": "^0.2.1",
-                        "kind-of": "^6.0.2",
-                        "nanomatch": "^1.2.9",
-                        "object.pick": "^1.3.0",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.2"
-                    }
-                },
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved":
-                        "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
-                }
+                "walker": "~1.0.5"
             }
         },
         "sax": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-            "integrity":
-                "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
             "dev": true
         },
         "semver": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-            "integrity":
-                "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+            "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
             "dev": true
         },
         "set-blocking": {
             "version": "2.0.0",
-            "resolved":
-                "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
             "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
             "dev": true
         },
         "set-value": {
-            "version": "2.0.0",
-            "resolved":
-                "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-            "integrity":
-                "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+            "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
             "dev": true,
             "requires": {
                 "extend-shallow": "^2.0.1",
@@ -5342,8 +4582,7 @@
             "dependencies": {
                 "extend-shallow": {
                     "version": "2.0.1",
-                    "resolved":
-                        "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
@@ -5354,8 +4593,7 @@
         },
         "shebang-command": {
             "version": "1.2.0",
-            "resolved":
-                "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "dev": true,
             "requires": {
@@ -5364,46 +4602,38 @@
         },
         "shebang-regex": {
             "version": "1.0.0",
-            "resolved":
-                "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
             "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
             "dev": true
         },
         "shellwords": {
             "version": "0.1.1",
-            "resolved":
-                "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-            "integrity":
-                "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+            "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+            "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
             "dev": true
         },
         "signal-exit": {
             "version": "3.0.2",
-            "resolved":
-                "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
             "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
             "dev": true
         },
         "sisteransi": {
-            "version": "0.1.1",
-            "resolved":
-                "https://registry.npmjs.org/sisteransi/-/sisteransi-0.1.1.tgz",
-            "integrity":
-                "sha512-PmGOd02bM9YO5ifxpw36nrNMBTptEtfRl4qUYl9SndkolplkrZZOW7PGHjrZL53QvMVj9nQ+TKqUnRsw4tJa4g==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.0.tgz",
+            "integrity": "sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ==",
             "dev": true
         },
         "slash": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-            "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+            "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
             "dev": true
         },
         "snapdragon": {
             "version": "0.8.2",
-            "resolved":
-                "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-            "integrity":
-                "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+            "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+            "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
             "dev": true,
             "requires": {
                 "base": "^0.11.1",
@@ -5418,8 +4648,7 @@
             "dependencies": {
                 "define-property": {
                     "version": "0.2.5",
-                    "resolved":
-                        "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
@@ -5428,22 +4657,25 @@
                 },
                 "extend-shallow": {
                     "version": "2.0.1",
-                    "resolved":
-                        "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
                 }
             }
         },
         "snapdragon-node": {
             "version": "2.1.1",
-            "resolved":
-                "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-            "integrity":
-                "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+            "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+            "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
             "dev": true,
             "requires": {
                 "define-property": "^1.0.0",
@@ -5453,8 +4685,7 @@
             "dependencies": {
                 "define-property": {
                     "version": "1.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
@@ -5463,10 +4694,8 @@
                 },
                 "is-accessor-descriptor": {
                     "version": "1.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-                    "integrity":
-                        "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
@@ -5474,10 +4703,8 @@
                 },
                 "is-data-descriptor": {
                     "version": "1.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-                    "integrity":
-                        "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
@@ -5485,58 +4712,47 @@
                 },
                 "is-descriptor": {
                     "version": "1.0.2",
-                    "resolved":
-                        "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-                    "integrity":
-                        "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
                         "kind-of": "^6.0.2"
                     }
-                },
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved":
-                        "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
-                },
-                "kind-of": {
-                    "version": "6.0.2",
-                    "resolved":
-                        "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity":
-                        "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-                    "dev": true
                 }
             }
         },
         "snapdragon-util": {
             "version": "3.0.1",
-            "resolved":
-                "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-            "integrity":
-                "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+            "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+            "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "dev": true,
             "requires": {
                 "kind-of": "^3.2.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
             }
         },
         "source-map": {
-            "version": "0.5.7",
-            "resolved":
-                "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "dev": true
         },
         "source-map-resolve": {
             "version": "0.5.2",
-            "resolved":
-                "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-            "integrity":
-                "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+            "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
             "dev": true,
             "requires": {
                 "atob": "^2.1.1",
@@ -5547,29 +4763,25 @@
             }
         },
         "source-map-support": {
-            "version": "0.4.18",
-            "resolved":
-                "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-            "integrity":
-                "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+            "version": "0.5.12",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+            "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
             "dev": true,
             "requires": {
-                "source-map": "^0.5.6"
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
             }
         },
         "source-map-url": {
             "version": "0.4.0",
-            "resolved":
-                "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+            "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
             "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
             "dev": true
         },
         "spdx-correct": {
-            "version": "3.0.2",
-            "resolved":
-                "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
-            "integrity":
-                "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+            "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
             "dev": true,
             "requires": {
                 "spdx-expression-parse": "^3.0.0",
@@ -5578,18 +4790,14 @@
         },
         "spdx-exceptions": {
             "version": "2.2.0",
-            "resolved":
-                "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-            "integrity":
-                "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+            "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
             "dev": true
         },
         "spdx-expression-parse": {
             "version": "3.0.0",
-            "resolved":
-                "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-            "integrity":
-                "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+            "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
             "dev": true,
             "requires": {
                 "spdx-exceptions": "^2.1.0",
@@ -5597,36 +4805,24 @@
             }
         },
         "spdx-license-ids": {
-            "version": "3.0.2",
-            "resolved":
-                "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
-            "integrity":
-                "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
+            "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
             "dev": true
         },
         "split-string": {
             "version": "3.1.0",
-            "resolved":
-                "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-            "integrity":
-                "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+            "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+            "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
             "dev": true,
             "requires": {
                 "extend-shallow": "^3.0.0"
             }
         },
-        "sprintf-js": {
-            "version": "1.0.3",
-            "resolved":
-                "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-            "dev": true
-        },
         "sshpk": {
-            "version": "1.15.2",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
-            "integrity":
-                "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+            "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
             "dev": true,
             "requires": {
                 "asn1": "~0.2.3",
@@ -5641,16 +4837,14 @@
             }
         },
         "stack-utils": {
-            "version": "1.0.1",
-            "resolved":
-                "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
-            "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
+            "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
             "dev": true
         },
         "static-extend": {
             "version": "0.1.2",
-            "resolved":
-                "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
             "dev": true,
             "requires": {
@@ -5660,8 +4854,7 @@
             "dependencies": {
                 "define-property": {
                     "version": "0.2.5",
-                    "resolved":
-                        "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
@@ -5672,92 +4865,103 @@
         },
         "stealthy-require": {
             "version": "1.1.1",
-            "resolved":
-                "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
             "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
             "dev": true
         },
         "string-length": {
             "version": "2.0.0",
-            "resolved":
-                "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
             "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
             "dev": true,
             "requires": {
                 "astral-regex": "^1.0.0",
                 "strip-ansi": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
             }
         },
         "string-width": {
             "version": "2.1.1",
-            "resolved":
-                "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-            "integrity":
-                "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
             "dev": true,
             "requires": {
                 "is-fullwidth-code-point": "^2.0.0",
                 "strip-ansi": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
             }
         },
         "string_decoder": {
             "version": "1.1.1",
-            "resolved":
-                "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity":
-                "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
             "requires": {
                 "safe-buffer": "~5.1.0"
             }
         },
         "strip-ansi": {
-            "version": "4.0.0",
-            "resolved":
-                "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+            "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
             "dev": true,
             "requires": {
-                "ansi-regex": "^3.0.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                    "dev": true
-                }
+                "ansi-regex": "^4.1.0"
             }
         },
         "strip-bom": {
-            "version": "2.0.0",
-            "resolved":
-                "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-            "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-            "dev": true,
-            "requires": {
-                "is-utf8": "^0.2.0"
-            }
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+            "dev": true
         },
         "strip-eof": {
             "version": "1.0.0",
-            "resolved":
-                "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
             "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
             "dev": true
         },
         "strip-indent": {
             "version": "2.0.0",
-            "resolved":
-                "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
             "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
             "dev": true
         },
         "supports-color": {
             "version": "4.5.0",
-            "resolved":
-                "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
             "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
             "dev": true,
             "requires": {
@@ -5765,25 +4969,21 @@
             }
         },
         "symbol-tree": {
-            "version": "3.2.2",
-            "resolved":
-                "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-            "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true
         },
         "test-exclude": {
-            "version": "4.2.3",
-            "resolved":
-                "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.3.tgz",
-            "integrity":
-                "sha512-SYbXgY64PT+4GAL2ocI3HwPa4Q4TBKm0cwAVeKOt/Aoc0gSpNRjJX8w0pA1LMKZ3LBmd8pYBqApFNQLII9kavA==",
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
+            "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
             "dev": true,
             "requires": {
-                "arrify": "^1.0.1",
-                "micromatch": "^2.3.11",
-                "object-assign": "^4.1.0",
-                "read-pkg-up": "^1.0.1",
-                "require-main-filename": "^1.0.1"
+                "glob": "^7.1.3",
+                "minimatch": "^3.0.4",
+                "read-pkg-up": "^4.0.0",
+                "require-main-filename": "^2.0.0"
             }
         },
         "throat": {
@@ -5799,28 +4999,35 @@
             "dev": true
         },
         "to-fast-properties": {
-            "version": "1.0.3",
-            "resolved":
-                "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-            "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+            "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
             "dev": true
         },
         "to-object-path": {
             "version": "0.3.0",
-            "resolved":
-                "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
             "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
             }
         },
         "to-regex": {
             "version": "3.0.2",
-            "resolved":
-                "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-            "integrity":
-                "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+            "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+            "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
             "dev": true,
             "requires": {
                 "define-property": "^2.0.2",
@@ -5831,46 +5038,22 @@
         },
         "to-regex-range": {
             "version": "2.1.1",
-            "resolved":
-                "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
             "dev": true,
             "requires": {
                 "is-number": "^3.0.0",
                 "repeat-string": "^1.6.1"
-            },
-            "dependencies": {
-                "is-number": {
-                    "version": "3.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    }
-                }
             }
         },
         "tough-cookie": {
-            "version": "2.4.3",
-            "resolved":
-                "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-            "integrity":
-                "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+            "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
             "dev": true,
             "requires": {
-                "psl": "^1.1.24",
-                "punycode": "^1.4.1"
-            },
-            "dependencies": {
-                "punycode": {
-                    "version": "1.4.1",
-                    "resolved":
-                        "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-                    "dev": true
-                }
+                "psl": "^1.1.28",
+                "punycode": "^2.1.1"
             }
         },
         "tr46": {
@@ -5884,15 +5067,13 @@
         },
         "trim-right": {
             "version": "1.0.1",
-            "resolved":
-                "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
             "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
             "dev": true
         },
         "tunnel-agent": {
             "version": "0.6.0",
-            "resolved":
-                "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "dev": true,
             "requires": {
@@ -5901,15 +5082,13 @@
         },
         "tweetnacl": {
             "version": "0.14.5",
-            "resolved":
-                "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
             "dev": true
         },
         "type-check": {
             "version": "0.3.2",
-            "resolved":
-                "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
             "dev": true,
             "requires": {
@@ -5917,78 +5096,37 @@
             }
         },
         "typescript": {
-            "version": "2.6.2",
-            "resolved":
-                "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-            "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
+            "integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
             "dev": true
         },
         "uglify-js": {
-            "version": "3.4.9",
-            "resolved":
-                "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-            "integrity":
-                "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
+            "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
             "dev": true,
             "optional": true,
             "requires": {
-                "commander": "~2.17.1",
+                "commander": "~2.20.0",
                 "source-map": "~0.6.1"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved":
-                        "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity":
-                        "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true,
-                    "optional": true
-                }
             }
         },
         "union-value": {
-            "version": "1.0.0",
-            "resolved":
-                "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-            "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+            "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
             "dev": true,
             "requires": {
                 "arr-union": "^3.1.0",
                 "get-value": "^2.0.6",
                 "is-extendable": "^0.1.1",
-                "set-value": "^0.4.3"
-            },
-            "dependencies": {
-                "extend-shallow": {
-                    "version": "2.0.1",
-                    "resolved":
-                        "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
-                    "requires": {
-                        "is-extendable": "^0.1.0"
-                    }
-                },
-                "set-value": {
-                    "version": "0.4.3",
-                    "resolved":
-                        "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-                    "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-                    "dev": true,
-                    "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-extendable": "^0.1.1",
-                        "is-plain-object": "^2.0.1",
-                        "to-object-path": "^0.3.0"
-                    }
-                }
+                "set-value": "^2.0.1"
             }
         },
         "unset-value": {
             "version": "1.0.0",
-            "resolved":
-                "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
             "dev": true,
             "requires": {
@@ -5998,8 +5136,7 @@
             "dependencies": {
                 "has-value": {
                     "version": "0.3.1",
-                    "resolved":
-                        "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+                    "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
                     "dev": true,
                     "requires": {
@@ -6010,8 +5147,7 @@
                     "dependencies": {
                         "isobject": {
                             "version": "2.1.0",
-                            "resolved":
-                                "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                             "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
                             "dev": true,
                             "requires": {
@@ -6022,18 +5158,19 @@
                 },
                 "has-values": {
                     "version": "0.1.4",
-                    "resolved":
-                        "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+                    "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
                     "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
                     "dev": true
-                },
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved":
-                        "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
                 }
+            }
+        },
+        "uri-js": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+            "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+            "dev": true,
+            "requires": {
+                "punycode": "^2.1.0"
             }
         },
         "urix": {
@@ -6045,23 +5182,19 @@
         "use": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-            "integrity":
-                "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+            "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
             "dev": true
         },
         "util-deprecate": {
             "version": "1.0.2",
-            "resolved":
-                "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
             "dev": true
         },
         "util.promisify": {
             "version": "1.0.0",
-            "resolved":
-                "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
-            "integrity":
-                "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+            "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+            "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
             "dev": true,
             "requires": {
                 "define-properties": "^1.1.2",
@@ -6071,16 +5204,13 @@
         "uuid": {
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-            "integrity":
-                "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
             "dev": true
         },
         "validate-npm-package-license": {
             "version": "3.0.4",
-            "resolved":
-                "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-            "integrity":
-                "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
             "dev": true,
             "requires": {
                 "spdx-correct": "^3.0.0",
@@ -6100,8 +5230,7 @@
         },
         "w3c-hr-time": {
             "version": "1.0.1",
-            "resolved":
-                "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
             "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
             "dev": true,
             "requires": {
@@ -6117,58 +5246,31 @@
                 "makeerror": "1.0.x"
             }
         },
-        "watch": {
-            "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
-            "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
-            "dev": true,
-            "requires": {
-                "exec-sh": "^0.2.0",
-                "minimist": "^1.2.0"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved":
-                        "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
-                }
-            }
-        },
         "webidl-conversions": {
             "version": "4.0.2",
-            "resolved":
-                "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-            "integrity":
-                "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+            "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
             "dev": true
         },
         "whatwg-encoding": {
             "version": "1.0.5",
-            "resolved":
-                "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
-            "integrity":
-                "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+            "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
             "dev": true,
             "requires": {
                 "iconv-lite": "0.4.24"
             }
         },
         "whatwg-mimetype": {
-            "version": "2.2.0",
-            "resolved":
-                "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.2.0.tgz",
-            "integrity":
-                "sha512-5YSO1nMd5D1hY3WzAQV3PzZL83W3YeyR1yW9PcH26Weh1t+Vzh9B6XkDh7aXm83HBZ4nSMvkjvN2H2ySWIvBgw==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+            "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
             "dev": true
         },
         "whatwg-url": {
             "version": "6.5.0",
-            "resolved":
-                "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
-            "integrity":
-                "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+            "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
             "dev": true,
             "requires": {
                 "lodash.sortby": "^4.7.0",
@@ -6179,8 +5281,7 @@
         "which": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-            "integrity":
-                "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+            "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
             "dev": true,
             "requires": {
                 "isexe": "^2.0.0"
@@ -6188,22 +5289,19 @@
         },
         "which-module": {
             "version": "2.0.0",
-            "resolved":
-                "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
             "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
             "dev": true
         },
         "wordwrap": {
             "version": "0.0.3",
-            "resolved":
-                "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
             "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
             "dev": true
         },
         "wrap-ansi": {
             "version": "2.1.0",
-            "resolved":
-                "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "dev": true,
             "requires": {
@@ -6211,10 +5309,15 @@
                 "strip-ansi": "^3.0.1"
             },
             "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
-                    "resolved":
-                        "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "dev": true,
                     "requires": {
@@ -6223,8 +5326,7 @@
                 },
                 "string-width": {
                     "version": "1.0.2",
-                    "resolved":
-                        "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                     "dev": true,
                     "requires": {
@@ -6235,8 +5337,7 @@
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
-                    "resolved":
-                        "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
@@ -6252,11 +5353,9 @@
             "dev": true
         },
         "write-file-atomic": {
-            "version": "2.3.0",
-            "resolved":
-                "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-            "integrity":
-                "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
+            "integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.11",
@@ -6267,8 +5366,7 @@
         "ws": {
             "version": "5.2.2",
             "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-            "integrity":
-                "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+            "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
             "dev": true,
             "requires": {
                 "async-limiter": "~1.0.0"
@@ -6276,54 +5374,101 @@
         },
         "xml-name-validator": {
             "version": "3.0.0",
-            "resolved":
-                "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-            "integrity":
-                "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+            "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
             "dev": true
         },
         "y18n": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+            "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
             "dev": true
         },
         "yallist": {
             "version": "2.1.2",
-            "resolved":
-                "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
             "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
             "dev": true
         },
         "yargs": {
-            "version": "11.1.0",
-            "resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
-            "integrity":
-                "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
+            "version": "12.0.5",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+            "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
             "dev": true,
             "requires": {
                 "cliui": "^4.0.0",
-                "decamelize": "^1.1.1",
-                "find-up": "^2.1.0",
+                "decamelize": "^1.2.0",
+                "find-up": "^3.0.0",
                 "get-caller-file": "^1.0.1",
-                "os-locale": "^2.0.0",
+                "os-locale": "^3.0.0",
                 "require-directory": "^2.1.1",
                 "require-main-filename": "^1.0.1",
                 "set-blocking": "^2.0.0",
                 "string-width": "^2.0.0",
                 "which-module": "^2.0.0",
-                "y18n": "^3.2.1",
-                "yargs-parser": "^9.0.2"
+                "y18n": "^3.2.1 || ^4.0.0",
+                "yargs-parser": "^11.1.1"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+                    "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "dev": true
+                },
+                "require-main-filename": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+                    "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+                    "dev": true
+                }
             }
         },
         "yargs-parser": {
-            "version": "9.0.2",
-            "resolved":
-                "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-            "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+            "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
             "dev": true,
             "requires": {
-                "camelcase": "^4.1.0"
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,12 @@
     "version": "1.1.1",
     "description": "Simple SDK for accessing OP APIs",
     "homepage": "https://github.com/op-developer/op-api-javascript-sdk",
-    "keywords": ["OP API", "OP-Developer", "OPEN OP", "OP SDK"],
+    "keywords": [
+        "OP API",
+        "OP-Developer",
+        "OPEN OP",
+        "OP SDK"
+    ],
     "bugs": {
         "url": "https://github.com/op-developer/op-api-javascript-sdk/issues"
     },
@@ -25,25 +30,31 @@
     },
     "dependencies": {
         "@types/axios": "^0.14.0",
-        "@types/node": "^10.11.5",
-        "axios": "^0.17.1",
+        "@types/node": "^10.14.10",
+        "axios": "^0.19.0",
         "object-assign-deep": "^0.3.1"
     },
     "devDependencies": {
-        "@types/jest": "^22.1.3",
-        "hoek": "^5.0.3",
+        "@types/jest": "^22.2.3",
+        "hoek": "^5.0.4",
         "husky": "^0.14.3",
-        "jest": "^23.6.0",
-        "prettier": "^1.11.1",
-        "pretty-quick": "^1.4.1",
-        "typescript": "^2.6.2"
+        "jest": "^24.8.0",
+        "prettier": "^1.18.2",
+        "pretty-quick": "^1.11.1",
+        "typescript": "^3.5.2"
     },
     "jest": {
-        "moduleFileExtensions": ["ts", "tsx", "js"],
+        "moduleFileExtensions": [
+            "ts",
+            "tsx",
+            "js"
+        ],
         "testEnvironment": "node",
         "transform": {
             "^.+\\.(ts|tsx)$": "./preprocessor.js"
         },
-        "testMatch": ["**/tests/*.(ts|tsx|js)"]
+        "testMatch": [
+            "**/tests/*.(ts|tsx|js)"
+        ]
     }
 }

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosRequestConfig } from 'axios';
+import axios, { AxiosRequestConfig, Method } from 'axios';
 import { Options } from './DataSchemas';
 import noResponseError from './error';
 
@@ -7,7 +7,7 @@ const request = async (method: string, path: string, options: Options) => {
         headers: options.headers,
         baseURL: options.baseURL,
         timeout: options.timeout,
-        method: method,
+        method: method as Method,
         url: path,
         data: options.data
     };


### PR DESCRIPTION
Updated dependencies to fix vulnerabilities.

To fix vulnerabilities in jest, required to upgrade jest from version 32 to version 24, which in turn required us to upgrade typescript from version 2 t o version 3, but these upgraded did not have any breaking changes in out code.

Only change outside package.json happend after updating axios from v0.17.1 to v0.19.0 were we required to cast method attribute as axios Method type in requestOptions is src/utils/request.ts